### PR TITLE
Allow multiple semanticIds for UserPlugins

### DIFF
--- a/aas-web-ui/src/UserPlugins/HelloWorldPlugin.vue
+++ b/aas-web-ui/src/UserPlugins/HelloWorldPlugin.vue
@@ -3,7 +3,7 @@
         <!-- Plugin Title -->
         <v-card class="mb-3">
             <v-card-title>
-                <div class="text-subtitle-1">{{ 'Hello World Plugin:' }}</div>
+                <div class="text-subtitle-1">{{ nameToDisplay(submodelElementData) }}</div>
             </v-card-title>
         </v-card>
         <!-- Iterate over all SubmodelElements of the HelloWorld-Plugin -->
@@ -25,12 +25,13 @@
     import { useAASStore } from '@/store/AASDataStore';
 
     export default defineComponent({
-        name: 'PluginJSONArray',
-        SemanticID: 'http://hello.world.de/plugin_submodel',
+        name: 'HelloWorldPlugin',
+        // semanticId: 'http://hello.world.de/plugin_submodel', // semanticId of the HelloWorld-Plugin as string
+        semanticId: ['http://hello.world.de/plugin_submodel', 'http://hello.world.de/plugin_property'], // semanticId of the HelloWorld-Plugin as array to use multiple semanticIds
         components: {
             SubmodelElementWrapper,
         },
-        mixins: [RequestHandling, SubmodelElementHandling], // SemanticID of the HelloWorld-Plugin
+        mixins: [RequestHandling, SubmodelElementHandling], // semanticId of the HelloWorld-Plugin
         props: ['submodelElementData'],
 
         setup() {

--- a/aas-web-ui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
+++ b/aas-web-ui/src/components/SubmodelPlugins/_SubmodelEntrypoint.vue
@@ -161,8 +161,17 @@
             // Filtered Plugins
             filteredPlugins() {
                 return this.ImportedPlugins.filter((plugin: any) => {
-                    // console.log(plugin.SemanticID === this.submodelElementData.semanticId.keys[0].value ? 'Plugin found: ' + plugin.SemanticID : 'Plugin not found: ' + plugin.SemanticID);
-                    return plugin.SemanticID === this.submodelElementData.semanticId.keys[0].value;
+                    if (!plugin.semanticId) return false;
+
+                    if (typeof plugin.semanticId === 'string') {
+                        return this.checkSemanticId(this.submodelElementData, plugin.semanticId);
+                    } else if (plugin.semanticId.constructor === Array) {
+                        for (const pluginSemanticId of plugin.semanticId) {
+                            if (this.checkSemanticId(this.submodelElementData, pluginSemanticId)) return true;
+                        }
+                        return false;
+                    }
+                    return false;
                 });
             },
 

--- a/aas-web-ui/src/main.ts
+++ b/aas-web-ui/src/main.ts
@@ -7,7 +7,7 @@
 // Types
 interface PluginType {
     name: string;
-    SemanticID: string;
+    semanticId: string;
 }
 
 // Components
@@ -63,7 +63,7 @@ async function loadUserPlugins() {
             const componentName = path.replace('./UserPlugins/', '').replace('.vue', '');
             const component: any = await pluginFiles[path]();
             app.component(componentName, (component.default || component) as ReturnType<typeof defineComponent>);
-            plugins.push({ name: componentName, SemanticID: component.default.SemanticID });
+            plugins.push({ name: componentName, semanticId: component.default.semanticId });
         })
     );
 

--- a/aas-web-ui/src/store/NavigationStore.ts
+++ b/aas-web-ui/src/store/NavigationStore.ts
@@ -31,7 +31,7 @@ export interface PlatformType {
 
 export interface PluginType {
     name: string;
-    SemanticID: string;
+    semanticId: string;
 }
 
 import { defineStore } from 'pinia';


### PR DESCRIPTION
Previously, UserPlugins could only be created for one specific semanticId.
This extension allows the use of a UserPlugin for several semanticIds.

Also
- renamed attribute "SemanticID" of PluginType interface to "semanticId")
- fix name of HelloWorldPlugin
- usage of nameToDisplay() for the HelloWorldPlugin title