### PR TITLE
Fixed RegExp for checking semanticId

### DIFF
--- a/aas-web-ui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-web-ui/src/mixins/SubmodelElementHandling.ts
@@ -119,14 +119,14 @@ export default defineComponent({
             for (const key of submodelElement.semanticId.keys) {
                 if (key.value.startsWith('http://') || key.value.startsWith('https://')) {
                     // e.g. IDTA IRI like
-                    if (new RegExp('/d/d/{0,1}' + '$').test(semanticId)) {
+                    if (new RegExp(/\/\d\/\d\/{1}/).test(semanticId)) {
                         if (key.value === semanticId) return true;
                     } else {
                         if (key.value.startsWith(semanticId)) return true;
                     }
                 } else if (key.value.startsWith('0173-1')) {
                     // ECLASS IRDI like 0173-1#01-AHF578#001 resp. 0173-1-01-AHF578-001
-                    if (new RegExp('[#-]{1}d{3}$').test(semanticId)) {
+                    if (new RegExp(/[#-]{1}d{3}$/).test(semanticId)) {
                         // ECLASS IRDI with version (like 0173-1#01-AHF578#001 resp. 0173-1-01-AHF578-001)
                         if (key.value === semanticId) return true;
                     } else {


### PR DESCRIPTION
checkSemanticId() worked not correct

E.g. for 'https://admin-shell.io/zvei/nameplate/2/0/Nameplate/CompanyLogo' the visualization of the SMT Nameplate was loaded ('https://admin-shell.io/zvei/nameplate/2/0/Nameplate')