### PR TITLE
Improves endpoint handling of descriptors

### DIFF
--- a/aas-web-ui/src/App.vue
+++ b/aas-web-ui/src/App.vue
@@ -27,6 +27,7 @@
             protocolInformation: {
                 href: string;
             };
+            interface: string;
         }>;
     }
 
@@ -118,7 +119,7 @@
                 // console.log('AAS Query is set: ', aasEndpoint);
                 let aas = {} as AASType;
                 let endpoints = [];
-                endpoints.push({ protocolInformation: { href: aasEndpoint } });
+                endpoints.push({ protocolInformation: { href: aasEndpoint }, interface: 'AAS-3.0' });
                 aas.endpoints = endpoints;
                 // dispatch the AAS set by the URL to the store
                 this.aasStore.dispatchSelectedAAS(aas);

--- a/aas-web-ui/src/components/AASTreeview.vue
+++ b/aas-web-ui/src/components/AASTreeview.vue
@@ -149,13 +149,7 @@
             initializeTree() {
                 // console.log('Initialize Treeview', this.initialUpdate, this.initialNode);
                 // return if no endpoints are available
-                if (
-                    !this.SelectedAAS ||
-                    !this.SelectedAAS.endpoints ||
-                    this.SelectedAAS.endpoints.length === 0 ||
-                    !this.SelectedAAS.endpoints[0].protocolInformation ||
-                    !this.SelectedAAS.endpoints[0].protocolInformation.href
-                ) {
+                if (!this.SelectedAAS || !this.SelectedAAS.endpoints || this.SelectedAAS.endpoints.length === 0) {
                     // TODO: this seems to get executed on reload with a selected AAS
                     // this.navigationStore.dispatchSnackbar({ status: true, timeout: 4000, color: 'error', btnColor: 'buttonText', text: 'AAS with no (valid) Endpoint selected!' });
                     this.submodelData = [];
@@ -165,7 +159,8 @@
                 this.aasStore.dispatchLoadingState(true); // set loading state to true
                 this.submodelData = []; // reset Treeview Data
                 // retrieve AAS from endpoint
-                let path = this.SelectedAAS.endpoints[0].protocolInformation.href + '/submodel-refs';
+                const shellHref = this.extractEndpointHref(this.selectedAAS, 'AAS-3.0');
+                let path = shellHref + '/submodel-refs';
                 let context = 'retrieving Submodel References';
                 let disableMessage = false;
                 this.getRequest(path, context, disableMessage).then(async (response: any) => {
@@ -223,9 +218,10 @@
                     return this.getRequest(path, context, disableMessage).then((response: any) => {
                         if (response.success) {
                             // execute if the Request was successful
-                            let submodelEndpoint = response.data;
+                            const fetchedSubmodel = response.data;
                             // console.log('SubmodelEndpoint: ', submodelEndpoint);
-                            let path = submodelEndpoint.endpoints[0].protocolInformation.href;
+                            const submodelHref = this.extractEndpointHref(fetchedSubmodel, 'SUBMODEL-3.0');
+                            let path = submodelHref;
                             let context = 'retrieving Submodel Data';
                             let disableMessage = true;
                             return this.getRequest(path, context, disableMessage).then((response: any) => {
@@ -400,13 +396,7 @@
             // Function to initialize the treeview with route params
             initTreeWithRouteParams() {
                 // check if the SelectedAAS is already set in the Store and initialize the Treeview if so
-                if (
-                    this.SelectedAAS &&
-                    this.SelectedAAS.endpoints &&
-                    this.SelectedAAS.endpoints[0] &&
-                    this.SelectedAAS.endpoints[0].protocolInformation &&
-                    this.SelectedAAS.endpoints[0].protocolInformation.href
-                ) {
+                if (this.SelectedAAS && this.SelectedAAS.endpoints && this.SelectedAAS.endpoints.length > 0) {
                     // console.log('init Tree from Route Params: ', this.SelectedAAS);
                     this.initializeTree();
                 }

--- a/aas-web-ui/src/components/AppNavigation/AASList.vue
+++ b/aas-web-ui/src/components/AppNavigation/AASList.vue
@@ -592,7 +592,7 @@
                 try {
                     if (this.deleteSubmodels) {
                         const shellHref = this.extractEndpointHref(this.aasToDelete, 'AAS-3.0');
-                        const path = `${shellHref}/submodel-refs`;
+                        const path = shellHref + '/submodel-refs';
                         const context = 'retrieving Submodel References';
                         const disableMessage = false;
                         const response = await this.getRequest(path, context, disableMessage);

--- a/aas-web-ui/src/components/AppNavigation/AASList.vue
+++ b/aas-web-ui/src/components/AppNavigation/AASList.vue
@@ -314,7 +314,7 @@
                 // console.log('AAS Query is set: ', aasEndpoint);
                 let aas = {} as any;
                 let endpoints = [];
-                endpoints.push({ protocolInformation: { href: aasEndpoint } });
+                endpoints.push({ protocolInformation: { href: aasEndpoint }, interface: 'AAS-3.0' });
                 aas.endpoints = endpoints;
                 // dispatch the AAS set by the URL to the store
                 this.aasStore.dispatchSelectedAAS(aas);
@@ -396,7 +396,8 @@
                 // console.log('Check AAS Status: ', AAS);
                 // iterate over all AAS in the AAS List
                 this.AASData.forEach((AAS: any) => {
-                    let path = AAS.endpoints[0].protocolInformation.href;
+                    const shellHref = this.extractEndpointHref(AAS, 'AAS-3.0');
+                    let path = shellHref;
                     let context = 'evaluating AAS Status';
                     let disableMessage = true;
                     this.getRequest(path, context, disableMessage).then((response: any) => {
@@ -445,16 +446,16 @@
                     });
                     return;
                 }
-
+                const shellHref = this.extractEndpointHref(AAS, 'AAS-3.0');
                 if (this.isMobile) {
                     // Change to Treeview add AAS Endpoint as Query to the Router
                     this.router.push({
                         path: '/submodellist',
-                        query: { aas: AAS.endpoints[0].protocolInformation.href },
+                        query: { aas: shellHref },
                     });
                 } else {
                     // Add AAS Endpoint as Query to the Router
-                    this.router.push({ query: { aas: AAS.endpoints[0].protocolInformation.href } });
+                    this.router.push({ query: { aas: shellHref } });
                 }
                 // dispatch the selected AAS to the Store
                 this.aasStore.dispatchSelectedAAS(AAS);
@@ -466,7 +467,8 @@
             downloadAAS(AAS: any) {
                 // console.log('Download AAS: ', AAS);
                 // request the Submodel references for the AAS
-                let path = AAS.endpoints[0].protocolInformation.href + '/submodel-refs';
+                const shellHref = this.extractEndpointHref(AAS, 'AAS-3.0');
+                let path = shellHref + '/submodel-refs';
                 let context = 'retrieving Submodel References';
                 let disableMessage = false;
                 this.getRequest(path, context, disableMessage).then(async (response: any) => {
@@ -513,9 +515,9 @@
                 ) {
                     return false;
                 }
-                let isSelected =
-                    this.selectedAAS['endpoints'][0]['protocolInformation']['href'] ===
-                    AAS['endpoints'][0]['protocolInformation']['href'];
+                const shellHrefAASfromList = this.extractEndpointHref(AAS, 'AAS-3.0');
+                const shellHrefSelectedAAS = this.extractEndpointHref(this.selectedAAS, 'AAS-3.0');
+                let isSelected = shellHrefAASfromList === shellHrefSelectedAAS;
                 if (isSelected && this.showDetailsCard) {
                     // update data of detailsCard
                     this.detailsObject = AAS;
@@ -577,7 +579,8 @@
                     return;
                 }
                 // console.log('Remove AAS: ', AAS);
-                let path = AAS.endpoints[0].protocolInformation.href;
+                const shellHref = this.extractEndpointHref(AAS, 'AAS-3.0');
+                let path = shellHref;
                 let context = 'removing AAS';
                 let disableMessage = false;
                 this.deleteRequest(path, context, disableMessage);
@@ -588,7 +591,8 @@
                 let error = false;
                 try {
                     if (this.deleteSubmodels) {
-                        const path = `${this.aasToDelete.endpoints[0].protocolInformation.href}/submodel-refs`;
+                        const shellHref = this.extractEndpointHref(this.aasToDelete, 'AAS-3.0');
+                        const path = `${shellHref}/submodel-refs`;
                         const context = 'retrieving Submodel References';
                         const disableMessage = false;
                         const response = await this.getRequest(path, context, disableMessage);
@@ -606,7 +610,11 @@
                                     disableMessage
                                 );
                                 if (submodelResponse.success) {
-                                    const deletePath = submodelResponse.data.endpoints[0].protocolInformation.href;
+                                    const submodelHref = this.extractEndpointHref(
+                                        submodelResponse.data,
+                                        'SUBMODEL-3.0'
+                                    );
+                                    const deletePath = submodelHref;
                                     await this.deleteRequest(deletePath, 'removing Submodel', disableMessage);
                                 } else {
                                     error = true;

--- a/aas-web-ui/src/components/AppNavigation/AASListDetails.vue
+++ b/aas-web-ui/src/components/AppNavigation/AASListDetails.vue
@@ -114,10 +114,7 @@
             fetchAssetDetails() {
                 // console.log('fetch asset details: ', this.detailsObject);
                 const shellHref = this.extractEndpointHref(this.detailsObject, 'AAS-3.0');
-                // strip everything after /shells from the shells href
-                let aasRepoEndpoint = shellHref.split('/shells')[0];
-                let assetInformationEndpoint =
-                    aasRepoEndpoint + '/shells/' + this.URLEncode(this.detailsObject.id) + '/asset-information';
+                const assetInformationEndpoint = shellHref + '/asset-information';
                 // console.log('aasRepoEndpoint: ', assetInformationEndpoint);
                 let path = assetInformationEndpoint;
                 let context = 'retrieving asset information';

--- a/aas-web-ui/src/components/AppNavigation/AASListDetails.vue
+++ b/aas-web-ui/src/components/AppNavigation/AASListDetails.vue
@@ -113,8 +113,9 @@
             // Function to fetch the Asset Details from the AAS Repository
             fetchAssetDetails() {
                 // console.log('fetch asset details: ', this.detailsObject);
-                // strip everything after /shells from detailsobject.endpoints[0].protocolInformation.href
-                let aasRepoEndpoint = this.detailsObject.endpoints[0].protocolInformation.href.split('/shells')[0];
+                const shellHref = this.extractEndpointHref(this.detailsObject, 'AAS-3.0');
+                // strip everything after /shells from the shells href
+                let aasRepoEndpoint = shellHref.split('/shells')[0];
                 let assetInformationEndpoint =
                     aasRepoEndpoint + '/shells/' + this.URLEncode(this.detailsObject.id) + '/asset-information';
                 // console.log('aasRepoEndpoint: ', assetInformationEndpoint);

--- a/aas-web-ui/src/components/ComponentVisualization.vue
+++ b/aas-web-ui/src/components/ComponentVisualization.vue
@@ -96,7 +96,7 @@
             SelectedNodeToTransfer() {
                 let aas = { ...this.aasStore.getSelectedAAS };
                 let node = { ...this.aasStore.getSelectedNode };
-                if (aas && aas.endpoints && aas.endpoints.length > 0) {
+                if (Array.isArray(aas?.endpoints) && aas?.endpoints.length > 0) {
                     const shellHref = this.extractEndpointHref(aas, 'AAS-3.0');
                     node.pathFull = shellHref + '/' + node.path;
                 }

--- a/aas-web-ui/src/components/ComponentVisualization.vue
+++ b/aas-web-ui/src/components/ComponentVisualization.vue
@@ -96,8 +96,9 @@
             SelectedNodeToTransfer() {
                 let aas = { ...this.aasStore.getSelectedAAS };
                 let node = { ...this.aasStore.getSelectedNode };
-                if (aas && aas.endpoints && aas.endpoints[0] && aas.endpoints[0].protocolInformation.href) {
-                    node.pathFull = aas.endpoints[0].protocolInformation.href + '/' + node.path;
+                if (aas && aas.endpoints && aas.endpoints.length > 0) {
+                    const shellHref = this.extractEndpointHref(aas, 'AAS-3.0');
+                    node.pathFull = shellHref + '/' + node.path;
                 }
                 // console.log('SelectedNodeToTransfer: ', node);
                 return node;
@@ -198,7 +199,7 @@
                     // console.log('AAS and Path Queries are set: ', aasEndpoint, ' | ', path);
                     let aas = {} as any;
                     let endpoints = [];
-                    endpoints.push({ protocolInformation: { href: aasEndpoint } });
+                    endpoints.push({ protocolInformation: { href: aasEndpoint }, interface: 'AAS-3.0' });
                     aas.endpoints = endpoints;
                     // dispatch the AAS set by the URL to the store
                     this.aasStore.dispatchSelectedAAS(aas);

--- a/aas-web-ui/src/components/SubmodelElements/Blob.vue
+++ b/aas-web-ui/src/components/SubmodelElements/Blob.vue
@@ -93,11 +93,12 @@
 <script lang="ts">
     import { defineComponent } from 'vue';
     import RequestHandling from '@/mixins/RequestHandling';
+    import SubmodelElementHandling from '@/mixins/SubmodelElementHandling';
     import { useAASStore } from '@/store/AASDataStore';
 
     export default defineComponent({
         name: 'Blob',
-        mixins: [RequestHandling],
+        mixins: [RequestHandling, SubmodelElementHandling],
         props: ['blobObject'],
 
         setup() {
@@ -174,8 +175,8 @@
             // Function to update the Blob of the File Element
             updateBlob() {
                 // console.log("Update Blob: " + this.newBlobValue);
-                let path =
-                    this.SelectedAAS.endpoints[0].protocolInformation.href + '/' + this.SelectedNode.path + '/value';
+                const shellHref = this.extractEndpointHref(this.SelectedAAS, 'AAS-3.0');
+                let path = shellHref + '/' + this.SelectedNode.path + '/value';
                 let content = "'" + this.newBlobValue + "'";
                 let headers = new Headers();
                 headers.append('Content-Type', 'application/json');

--- a/aas-web-ui/src/components/SubmodelList.vue
+++ b/aas-web-ui/src/components/SubmodelList.vue
@@ -166,13 +166,7 @@
             initSubmodelList() {
                 // console.log("initialize Submodel List: ", this.SelectedAAS);
                 // return if no endpoints are available
-                if (
-                    !this.SelectedAAS ||
-                    !this.SelectedAAS.endpoints ||
-                    this.SelectedAAS.endpoints.length === 0 ||
-                    !this.SelectedAAS.endpoints[0].protocolInformation ||
-                    !this.SelectedAAS.endpoints[0].protocolInformation.href
-                ) {
+                if (!this.SelectedAAS || !this.SelectedAAS.endpoints || this.SelectedAAS.endpoints.length === 0) {
                     // this.navigationStore.dispatchSnackbar({ status: true, timeout: 4000, color: 'error', btnColor: 'buttonText', text: 'AAS with no (valid) Endpoint selected!' });
                     this.submodelData = [];
                     return;
@@ -181,7 +175,8 @@
                 this.aasStore.dispatchLoadingState(true); // set loading state to true
                 this.submodelData = []; // reset Submdoel List Data
                 // retrieve AAS from endpoint
-                let path = this.SelectedAAS.endpoints[0].protocolInformation.href + '/submodel-refs';
+                const shellHref = this.extractEndpointHref(this.SelectedAAS, 'AAS-3.0');
+                let path = shellHref + '/submodel-refs';
                 let context = 'retrieving Submodel References';
                 let disableMessage = false;
                 this.getRequest(path, context, disableMessage).then(async (response: any) => {
@@ -243,9 +238,10 @@
                     return this.getRequest(path, context, disableMessage).then((response: any) => {
                         if (response.success) {
                             // execute if the Request was successful
-                            let submodelEndpoint = response.data;
+                            const fetchedSubmodel = response.data;
                             // console.log('SubmodelEndpoint: ', submodelEndpoint);
-                            let path = submodelEndpoint.endpoints[0].protocolInformation.href;
+                            const submodelHref = this.extractEndpointHref(fetchedSubmodel, 'SUBMODEL-3.0');
+                            let path = submodelHref;
                             let context = 'retrieving Submodel Data';
                             let disableMessage = true;
                             return this.getRequest(path, context, disableMessage).then((response: any) => {
@@ -283,12 +279,13 @@
                 });
                 // Add path of the selected Node to the URL as Router Query
                 if (localSubmodel.isActive) {
+                    const shellHref = this.extractEndpointHref(this.SelectedAAS, 'AAS-3.0');
                     if (this.isMobile) {
                         // Change to SubmodelElementView on Mobile and add the path to the URL
                         this.router.push({
                             path: '/componentvisualization',
                             query: {
-                                aas: this.SelectedAAS.endpoints[0].protocolInformation.href,
+                                aas: shellHref,
                                 path: localSubmodel.path,
                             },
                         });
@@ -296,7 +293,7 @@
                         // just add the path to the URL
                         this.router.push({
                             query: {
-                                aas: this.SelectedAAS.endpoints[0].protocolInformation.href,
+                                aas: shellHref,
                                 path: localSubmodel.path,
                             },
                         });
@@ -316,13 +313,7 @@
             // Function to initialize the Submodel List with the Route Parameters
             initSubmodelListWithRouteParameters() {
                 // check if the SelectedAAS is already set in the Store and initialize the Submodel List if so
-                if (
-                    this.SelectedAAS &&
-                    this.SelectedAAS.endpoints &&
-                    this.SelectedAAS.endpoints[0] &&
-                    this.SelectedAAS.endpoints[0].protocolInformation &&
-                    this.SelectedAAS.endpoints[0].protocolInformation.href
-                ) {
+                if (this.SelectedAAS && this.SelectedAAS.endpoints && this.SelectedAAS.endpoints.length > 0) {
                     // console.log('init Tree from Route Params: ', this.SelectedAAS);
                     this.initSubmodelList();
                 }

--- a/aas-web-ui/src/components/UIComponents/VTreeview.vue
+++ b/aas-web-ui/src/components/UIComponents/VTreeview.vue
@@ -156,12 +156,13 @@
                 localItem.isActive = !localItem.isActive;
                 // Add path of the selected Node to the URL as Router Query
                 if (localItem.isActive) {
+                    const shellHref = this.extractEndpointHref(this.SelectedAAS, 'AAS-3.0');
                     if (this.isMobile) {
                         // Change to SubmodelElementView on Mobile and add the path to the URL
                         this.router.push({
                             path: '/submodelelementview',
                             query: {
-                                aas: this.SelectedAAS.endpoints[0].protocolInformation.href,
+                                aas: shellHref,
                                 path: localItem.path,
                             },
                         });
@@ -169,7 +170,7 @@
                         // just add the path to the URL
                         this.router.push({
                             query: {
-                                aas: this.SelectedAAS.endpoints[0].protocolInformation.href,
+                                aas: shellHref,
                                 path: localItem.path,
                             },
                         });

--- a/aas-web-ui/src/mixins/DashboardHandling.ts
+++ b/aas-web-ui/src/mixins/DashboardHandling.ts
@@ -161,7 +161,8 @@ export default defineComponent({
                 // console.log(this.SelectedAAS)
                 return this.SelectedAAS;
             } else {
-                const path = this.SelectedAAS.endpoints[0].protocolInformation.href;
+                const shellHref = this.extractEndpointHref(this.SelectedAAS, 'AAS-3.0');
+                const path = shellHref;
                 const context = 'getting aas from endpoint';
                 const disableMessage = false;
                 const response = await this.getRequest(path, context, disableMessage);

--- a/aas-web-ui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-web-ui/src/mixins/SubmodelElementHandling.ts
@@ -257,7 +257,8 @@ export default defineComponent({
             referenceValue: Array<any>
         ): Promise<{ success: boolean; aas?: object; submodel?: object }> {
             const promises = aasList.map(async (aas: any) => {
-                const path = aas.endpoints[0].protocolInformation.href + '/submodel-refs';
+                const shellHref = this.extractEndpointHref(aas, 'AAS-3.0');
+                const path = shellHref + '/submodel-refs';
                 const context = 'retrieving Submodel References';
                 const disableMessage = false;
 
@@ -287,7 +288,8 @@ export default defineComponent({
         // Function to jump to a referenced Element
         jumpToReferencedElement(referencedAAS: any, referenceValue: Array<any>, referencedSubmodel?: any) {
             // console.log('jumpToReferencedElement. AAS: ', referencedAAS, 'Submodel: ', referencedSubmodel);
-            const endpoint = referencedAAS.endpoints[0].protocolInformation.href;
+            const shellHref = this.extractEndpointHref(referencedAAS, 'AAS-3.0');
+            const endpoint = shellHref;
             if (referencedSubmodel && Object.keys(referencedSubmodel).length > 0) {
                 // if the referenced Element is a Submodel or SubmodelElement
                 this.jumpToSubmodelElement(referencedSubmodel, referenceValue, referencedAAS, endpoint);
@@ -610,6 +612,20 @@ export default defineComponent({
                 if (displayNameEn && displayNameEn.text) return displayNameEn.text;
             }
             return sme.idShort ? sme.idShort : '';
+        },
+
+        // Extract the right endpoints href from a descriptor
+        extractEndpointHref(descriptor: any, interfaceShortName: string): string {
+            const endpoints = descriptor.endpoints;
+            // find the right endpoint based on the interfaceShortName (has to match endpoint.interface)
+            const endpoint = endpoints.find((endpoint: any) => {
+                return endpoint.interface === interfaceShortName;
+            });
+            if (endpoint) {
+                return endpoint.protocolInformation.href;
+            } else {
+                return '';
+            }
         },
     },
 });

--- a/aas-web-ui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-web-ui/src/mixins/SubmodelElementHandling.ts
@@ -616,16 +616,35 @@ export default defineComponent({
 
         // Extract the right endpoints href from a descriptor
         extractEndpointHref(descriptor: any, interfaceShortName: string): string {
+            const interfaceShortNames = [
+                'AAS',
+                'SUBMODEL',
+                'SERIALIZE',
+                'DESCRIPTION',
+                'AASX-FILE',
+                'AAS-REGISTRY',
+                'SUBMODEL-REGISTRY',
+                'AAS-REPOSITORY',
+                'SUBMODEL-REPOSITORY',
+                'CD-REPOSITORY',
+                'AAS-DISCOVERY',
+            ];
+            if (!interfaceShortNames.some((iShortName) => interfaceShortName.startsWith(`${iShortName}-`))) {
+                return '';
+            }
+            if (
+                !Array.isArray(descriptor?.endpoints) ||
+                descriptor?.endpoints.length === 0 ||
+                interfaceShortName === ''
+            ) {
+                return '';
+            }
             const endpoints = descriptor.endpoints;
             // find the right endpoint based on the interfaceShortName (has to match endpoint.interface)
             const endpoint = endpoints.find((endpoint: any) => {
-                return endpoint.interface === interfaceShortName;
+                return endpoint?.interface === interfaceShortName;
             });
-            if (endpoint) {
-                return endpoint.protocolInformation.href;
-            } else {
-                return '';
-            }
+            return endpoint?.protocolInformation?.href ? endpoint.protocolInformation.href : '';
         },
     },
 });


### PR DESCRIPTION
# Improves endpoint handling of descriptors

## Description of Changes

This PR improves the extraction of the right href from the endpoint of an AAS/Submodel descriptors.
It follows the API specifications in regards to extracting the right endpoint based on the interface-shortName (see screenshot)

![image](https://github.com/user-attachments/assets/cc1f6858-73a5-4301-b2c3-d3b34917f3bb)

## Related Issue

Closes #57 

## Additional Information

This fix makes it possible to use the BaSyx AAS Web UI as a frontend for the FA³ST service + registry.
For more details have a look at the issue on the FA³ST repo:
https://github.com/FraunhoferIOSB/FAAAST-Service/issues/914
