### PR TITLE
Handling not available submodel(-descriptor)

### DIFF
--- a/aas-web-ui/src/components/AASTreeview.vue
+++ b/aas-web-ui/src/components/AASTreeview.vue
@@ -251,47 +251,19 @@
                                         }
                                         return submodel;
                                     } else {
-                                        let submodel = {
-                                            id: submodelId,
-                                            idShort: 'Submodel not found',
-                                            modelType: 'Submodel',
-                                            semanticId: null,
-                                            description: [],
-                                            displayName: [],
-                                            submodelElements: [],
-                                            isActive: false,
-                                            path: path,
-                                        };
-                                        this.navigationStore.dispatchSnackbar({
-                                            status: true,
-                                            timeout: 60000,
-                                            color: 'error',
-                                            btnColor: 'buttonText',
-                                            text: "Submodel '" + submodelId + "' not found in SubmodelRepository",
-                                        });
-                                        return submodel;
+                                        return this.smNotFound(
+                                            submodelId,
+                                            path,
+                                            "Submodel '" + submodelId + "' not found in SubmodelRepository"
+                                        );
                                     }
                                 });
                             } else {
-                                let submodel = {
-                                    id: submodelId,
-                                    idShort: 'Submodel not found',
-                                    modelType: 'Submodel',
-                                    semanticId: null,
-                                    description: [],
-                                    displayName: [],
-                                    submodelElements: [],
-                                    isActive: false,
-                                    path: path,
-                                };
-                                this.navigationStore.dispatchSnackbar({
-                                    status: true,
-                                    timeout: 60000,
-                                    color: 'error',
-                                    btnColor: 'buttonText',
-                                    text: "Submodel '" + submodelId + "' not found in SubmodelRegistry",
-                                });
-                                return submodel;
+                                return this.smNotFound(
+                                    submodelId,
+                                    path,
+                                    "Submodel '" + submodelId + "' not found in SubmodelRegistry"
+                                );
                             }
                         }
                     });

--- a/aas-web-ui/src/components/AASTreeview.vue
+++ b/aas-web-ui/src/components/AASTreeview.vue
@@ -253,7 +253,7 @@
                                     } else {
                                         let submodel = {
                                             id: submodelId,
-                                            idShort: submodelId.split('/').pop(),
+                                            idShort: 'Submodel not found',
                                             modelType: 'Submodel',
                                             semanticId: null,
                                             description: [],
@@ -275,7 +275,7 @@
                             } else {
                                 let submodel = {
                                     id: submodelId,
-                                    idShort: submodelId.split('/').pop(),
+                                    idShort: 'Submodel not found',
                                     modelType: 'Submodel',
                                     semanticId: null,
                                     description: [],

--- a/aas-web-ui/src/components/AASTreeview.vue
+++ b/aas-web-ui/src/components/AASTreeview.vue
@@ -434,7 +434,7 @@
                 const path = searchParams.get('path');
 
                 if (aasEndpoint && path) {
-                    console.log('AAS and Path Queris are set: ', aasEndpoint, path);
+                    // console.log('AAS and Path Queris are set: ', aasEndpoint, path);
                     let node = {} as any;
                     node.path = path;
                     node.isActive = true;

--- a/aas-web-ui/src/components/SubmodelElementView.vue
+++ b/aas-web-ui/src/components/SubmodelElementView.vue
@@ -332,7 +332,7 @@
                 this.getRequest(path, context, disableMessage).then((response: any) => {
                     // save Concept Descriptions before overwriting the SubmodelElement Data
                     let conceptDescriptions = this.submodelElementData.conceptDescriptions;
-                    if (response.success) {
+                    if (response.success && (response.data?.id || response.data?.idShort)) {
                         // execute if the Request was successful
                         response.data.timestamp = this.formatDate(new Date()); // add timestamp to the SubmodelElement Data
                         response.data.path = this.SelectedNode.path; // add the path to the SubmodelElement Data

--- a/aas-web-ui/src/components/SubmodelList.vue
+++ b/aas-web-ui/src/components/SubmodelList.vue
@@ -259,47 +259,19 @@
                                         submodel.path = path;
                                         return submodel;
                                     } else {
-                                        let submodel = {
-                                            id: submodelId,
-                                            idShort: 'Submodel not found',
-                                            modelType: 'Submodel',
-                                            semanticId: null,
-                                            description: [],
-                                            displayName: [],
-                                            submodelElements: [],
-                                            isActive: false,
-                                            path: path,
-                                        };
-                                        this.navigationStore.dispatchSnackbar({
-                                            status: true,
-                                            timeout: 60000,
-                                            color: 'error',
-                                            btnColor: 'buttonText',
-                                            text: "Submodel '" + submodelId + "' not found in SubmodelRepository",
-                                        });
-                                        return submodel;
+                                        return this.smNotFound(
+                                            submodelId,
+                                            path,
+                                            "Submodel '" + submodelId + "' not found in SubmodelRepository"
+                                        );
                                     }
                                 });
                             } else {
-                                let submodel = {
-                                    id: submodelId,
-                                    idShort: 'Submodel not found',
-                                    modelType: 'Submodel',
-                                    semanticId: null,
-                                    description: [],
-                                    displayName: [],
-                                    submodelElements: [],
-                                    isActive: false,
-                                    path: path,
-                                };
-                                this.navigationStore.dispatchSnackbar({
-                                    status: true,
-                                    timeout: 60000,
-                                    color: 'error',
-                                    btnColor: 'buttonText',
-                                    text: "Submodel '" + submodelId + "' not found in SubmodelRegistry",
-                                });
-                                return submodel;
+                                return this.smNotFound(
+                                    submodelId,
+                                    path,
+                                    "Submodel '" + submodelId + "' not found in SubmodelRegistry"
+                                );
                             }
                         }
                     });

--- a/aas-web-ui/src/components/SubmodelList.vue
+++ b/aas-web-ui/src/components/SubmodelList.vue
@@ -184,7 +184,8 @@
                         // execute if the Request was successful
                         try {
                             // request submodels from the retrieved AAS
-                            let submodelData = await this.requestSubmodels(response.data.result);
+                            const submodelRefs = response.data.result;
+                            let submodelData = await this.requestSubmodels(submodelRefs);
                             if (this.initialUpdate && this.initialNode) {
                                 // set the isActive Property of the initial Node to true and dispatch it to the store
                                 submodelData.forEach((submodel: any) => {
@@ -232,31 +233,74 @@
                     if (!submodelRegistryURL.includes('/submodel-descriptors')) {
                         submodelRegistryURL += '/submodel-descriptors';
                     }
-                    let path = submodelRegistryURL + '/' + this.URLEncode(submodelRef.keys[0].value);
+                    const submodelId = submodelRef.keys[0].value;
+                    let path = submodelRegistryURL + '/' + this.URLEncode(submodelId);
                     let context = 'retrieving Submodel Endpoint';
                     let disableMessage = false;
                     return this.getRequest(path, context, disableMessage).then((response: any) => {
                         if (response.success) {
-                            // execute if the Request was successful
-                            const fetchedSubmodel = response.data;
-                            // console.log('SubmodelEndpoint: ', submodelEndpoint);
-                            const submodelHref = this.extractEndpointHref(fetchedSubmodel, 'SUBMODEL-3.0');
-                            let path = submodelHref;
-                            let context = 'retrieving Submodel Data';
-                            let disableMessage = true;
-                            return this.getRequest(path, context, disableMessage).then((response: any) => {
-                                if (response.success) {
-                                    // execute if the Request was successful
-                                    let submodel = response.data;
-                                    // give the Submodel a unique ID
-                                    submodel.id = this.UUID();
-                                    // set the active State of the Submodel
-                                    submodel.isActive = false;
-                                    // set the Path of the Submodel
-                                    submodel.path = path;
-                                    return submodel;
-                                }
-                            });
+                            if (response.data?.id) {
+                                // execute if the Request was successful
+                                const fetchedSubmodel = response.data;
+                                // console.log('SubmodelEndpoint: ', submodelEndpoint);
+                                const submodelHref = this.extractEndpointHref(fetchedSubmodel, 'SUBMODEL-3.0');
+                                let path = submodelHref;
+                                let context = 'retrieving Submodel Data';
+                                let disableMessage = true;
+                                return this.getRequest(path, context, disableMessage).then((response: any) => {
+                                    if (response.success && response?.data?.id) {
+                                        // execute if the Request was successful
+                                        let submodel = response.data;
+                                        // give the Submodel a unique ID
+                                        submodel.id = this.UUID();
+                                        // set the active State of the Submodel
+                                        submodel.isActive = false;
+                                        // set the Path of the Submodel
+                                        submodel.path = path;
+                                        return submodel;
+                                    } else {
+                                        let submodel = {
+                                            id: submodelId,
+                                            idShort: submodelId.split('/').pop(),
+                                            modelType: 'Submodel',
+                                            semanticId: null,
+                                            description: [],
+                                            displayName: [],
+                                            submodelElements: [],
+                                            isActive: false,
+                                            path: path,
+                                        };
+                                        this.navigationStore.dispatchSnackbar({
+                                            status: true,
+                                            timeout: 60000,
+                                            color: 'error',
+                                            btnColor: 'buttonText',
+                                            text: "Submodel '" + submodelId + "' not found in SubmodelRepository",
+                                        });
+                                        return submodel;
+                                    }
+                                });
+                            } else {
+                                let submodel = {
+                                    id: submodelId,
+                                    idShort: submodelId.split('/').pop(),
+                                    modelType: 'Submodel',
+                                    semanticId: null,
+                                    description: [],
+                                    displayName: [],
+                                    submodelElements: [],
+                                    isActive: false,
+                                    path: path,
+                                };
+                                this.navigationStore.dispatchSnackbar({
+                                    status: true,
+                                    timeout: 60000,
+                                    color: 'error',
+                                    btnColor: 'buttonText',
+                                    text: "Submodel '" + submodelId + "' not found in SubmodelRegistry",
+                                });
+                                return submodel;
+                            }
                         }
                     });
                 });

--- a/aas-web-ui/src/components/SubmodelList.vue
+++ b/aas-web-ui/src/components/SubmodelList.vue
@@ -261,7 +261,7 @@
                                     } else {
                                         let submodel = {
                                             id: submodelId,
-                                            idShort: submodelId.split('/').pop(),
+                                            idShort: 'Submodel not found',
                                             modelType: 'Submodel',
                                             semanticId: null,
                                             description: [],
@@ -283,7 +283,7 @@
                             } else {
                                 let submodel = {
                                     id: submodelId,
-                                    idShort: submodelId.split('/').pop(),
+                                    idShort: 'Submodel not found',
                                     modelType: 'Submodel',
                                     semanticId: null,
                                     description: [],

--- a/aas-web-ui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-web-ui/src/mixins/SubmodelElementHandling.ts
@@ -646,5 +646,29 @@ export default defineComponent({
             });
             return endpoint?.protocolInformation?.href ? endpoint.protocolInformation.href : '';
         },
+
+        smNotFound(submodelId: string, path: string, text: string) {
+            if (text.trim().length > 0) {
+                this.navigationStore.dispatchSnackbar({
+                    status: true,
+                    timeout: 60000,
+                    color: 'error',
+                    btnColor: 'buttonText',
+                    text: text,
+                });
+            }
+            const submodel = {
+                id: submodelId,
+                idShort: 'Submodel not found',
+                modelType: 'Submodel',
+                semanticId: null,
+                description: [],
+                displayName: [],
+                submodelElements: [],
+                isActive: false,
+                path: path,
+            };
+            return submodel;
+        },
     },
 });

--- a/aas-web-ui/src/mixins/SubmodelElementHandling.ts
+++ b/aas-web-ui/src/mixins/SubmodelElementHandling.ts
@@ -647,7 +647,7 @@ export default defineComponent({
             return endpoint?.protocolInformation?.href ? endpoint.protocolInformation.href : '';
         },
 
-        smNotFound(submodelId: string, path: string, text: string) {
+        smNotFound(submodelId: string, path: string, text: string): any {
             if (text.trim().length > 0) {
                 this.navigationStore.dispatchSnackbar({
                     status: true,


### PR DESCRIPTION
## Description of Changes

Up till now not available submodel (from sm repo) resp. submodel-descritptors (from sm registry) led to an error, see https://github.com/eclipse-basyx/basyx-aas-web-ui/issues/55

This PR tries to realisze some kind of  ‘soft’ reference of submodels.

### Case 1: submodel (via repo) available, submodel-descriptor (via registry) available
![1_all_ok](https://github.com/user-attachments/assets/d1bf9fa8-1e6c-4b34-b5ca-6cc00de0127e)

### Case 2: submodel (via repo) available, submodel-descriptor (via registry) NOT available
![2_registry_nok___repo_ok](https://github.com/user-attachments/assets/18a3f596-ffa0-48fb-a916-a3ad09adc50b)

### Case 3: submodel (via repo) NOT available, submodel-descriptor (via registry) available
![3_registry_ok___repo_nok](https://github.com/user-attachments/assets/4f04a922-efd4-4ef3-a210-4d0210781624)

### Case 4: submodel (via repo) NOT available, submodel-descriptor (via registry) NOT available
![4_registry_nok___repo_nok](https://github.com/user-attachments/assets/723b9df9-ea42-461b-af28-52936d941b69)

## Related Issue

https://github.com/eclipse-basyx/basyx-aas-web-ui/issues/55

