### PR TITLE
DockerHub tag for latest release

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,7 +29,7 @@ if [ "$build_images" = "y" ]; then
     docker buildx create --use --name basyx-builder
 
     # Build and push the Docker images
-    docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 -t eclipsebasyx/aas-gui:v2-$DATE . --push
+    docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --tag eclipsebasyx/aas-gui:v2-$DATE --tag eclipsebasyx/aas-gui:latest . --push
 else
     yarn dev --host
 fi


### PR DESCRIPTION
I propose to introduce a DockerHub tag that always refers to the latest release/verion of the aas-web-ui.

With such a tag, a user can ensure that the latest release/version of the aas-web-ui is always used.

Here: Proposal for tag ´latest´