### PR TITLE
Rolling back vue-tsc

### DIFF
--- a/aas-web-ui/package.json
+++ b/aas-web-ui/package.json
@@ -65,6 +65,6 @@
     "vite": "^6.0.3",
     "vite-plugin-vuetify": "^2.0.4",
     "vitest": "^2.1.8",
-    "vue-tsc": "^2.1.10"
+    "vue-tsc": "^2.1.4"
   }
 }

--- a/aas-web-ui/yarn.lock
+++ b/aas-web-ui/yarn.lock
@@ -4536,7 +4536,7 @@ vue-router@^4.5.0:
   dependencies:
     "@vue/devtools-api" "^6.6.4"
 
-vue-tsc@^2.1.10:
+vue-tsc@^2.1.4:
   version "2.1.10"
   resolved "https://registry.yarnpkg.com/vue-tsc/-/vue-tsc-2.1.10.tgz#4d61a64e5fad763b8b40c1884259fd48986f0b4e"
   integrity sha512-RBNSfaaRHcN5uqVqJSZh++Gy/YUzryuv9u1aFWhsammDJXNtUiJMNoJ747lZcQ68wUQFx6E73y4FY3D8E7FGMA==


### PR DESCRIPTION
The newer version of vue-tsc seems to have a problem. Therefore rolling back.
