### PR TITLE
Fixes title of AASTreeview/SubmodeList for AAS with missing displayName and idShort

### DIFF
--- a/aas-web-ui/src/components/AASTreeview.vue
+++ b/aas-web-ui/src/components/AASTreeview.vue
@@ -6,7 +6,7 @@
                 <div v-else class="d-flex align-center">
                     <v-icon icon="custom:aasIcon" color="primary" size="small" class="ml-2" />
                     <span class="text-truncate ml-2">
-                        {{ nameToDisplay(selectedAAS) }}
+                        {{ nameToDisplay(selectedAAS, 'en', selectedAAS.id) }}
                     </span>
                 </div>
                 <!-- TODO: Add Searchfield to filter the Treeview -->

--- a/aas-web-ui/src/components/SubmodelList.vue
+++ b/aas-web-ui/src/components/SubmodelList.vue
@@ -12,7 +12,7 @@
                         @click="backToAASList()" />
                     <v-icon icon="custom:aasIcon" color="primary" size="small" class="ml-2" />
                     <span class="text-truncate ml-2">
-                        {{ nameToDisplay(selectedAAS) }}
+                        {{ nameToDisplay(selectedAAS, 'en', selectedAAS.id) }}
                     </span>
                 </div>
             </v-card-title>


### PR DESCRIPTION
In case of a selected AAS without English displayName and without idShort just the AAS Icon was shown in the title of AASTreeview resp. SubmodelList.

This PR fixes the empty title by showing the mandatory available id of the AAS.