### PR TITLE
AAS Editor: Dispatching of new resp. edited selected AAS

### DIFF
--- a/aas-web-ui/src/components/EditorComponents/AAS.vue
+++ b/aas-web-ui/src/components/EditorComponents/AAS.vue
@@ -77,6 +77,7 @@
     import { computed, ref, watch } from 'vue';
     import { useAASRegistryClient } from '@/composables/Client/AASRegistryClient';
     import { useAASRepositoryClient } from '@/composables/Client/AASRepositoryClient';
+    import { useAASStore } from '@/store/AASDataStore';
     import { UUID } from '@/utils/IDUtils';
 
     const props = defineProps<{
@@ -85,11 +86,14 @@
         aas?: any;
     }>();
 
+    // Stores
+    const aasStore = useAASStore();
+
     const emit = defineEmits<{
         (event: 'update:modelValue', value: boolean): void;
     }>();
 
-    const { fetchAasById, postAas, putAas, putThumbnail } = useAASRepositoryClient();
+    const { fetchAasById, postAas, putAas, putThumbnail, fetchAndDispatchAasById } = useAASRepositoryClient();
     const { putAasDescriptor, createDescriptorFromAAS } = useAASRegistryClient();
 
     const editAASDialog = ref(false);
@@ -114,6 +118,8 @@
 
     const fileThumbnail = ref<File | undefined>(undefined);
 
+    // Computed Properties
+    const selectedAAS = computed(() => aasStore.getSelectedAAS); // Get the selected AAS from Store
     const bordersToShow = computed(() => (panel: number) => {
         let border = '';
         switch (panel) {
@@ -285,18 +291,22 @@
             await postAas(AASObject.value);
             // Upload default thumbnail
             if (fileThumbnail.value !== undefined) {
-                putThumbnail(fileThumbnail.value, AASObject.value.id);
+                await putThumbnail(fileThumbnail.value, AASObject.value.id);
             }
+            await fetchAndDispatchAasById(AASObject.value.id);
         } else {
             // Update existing AAS
             await putAas(AASObject.value);
             // Update AAS Descriptor
             const jsonAAS = jsonization.toJsonable(AASObject.value);
             const descriptor = createDescriptorFromAAS(jsonAAS, props.aas.endpoints);
-            putAasDescriptor(descriptor);
+            await putAasDescriptor(descriptor);
             // Upload default thumbnail
             if (fileThumbnail.value !== undefined) {
-                putThumbnail(fileThumbnail.value, AASObject.value.id);
+                await putThumbnail(fileThumbnail.value, AASObject.value.id);
+            }
+            if (AASObject.value.id === selectedAAS.value.id) {
+                await fetchAndDispatchAasById(AASObject.value.id);
             }
         }
         clearForm();

--- a/aas-web-ui/src/composables/Client/AASRegistryClient.ts
+++ b/aas-web-ui/src/composables/Client/AASRegistryClient.ts
@@ -86,11 +86,10 @@ export function useAASRegistryClient() {
         const body = JSON.stringify(aasDescriptor);
 
         // Send Request to upload the file
-        postRequest(path, body, headers, context, disableMessage).then((response: any) => {
-            if (response.success) {
-                navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
-            }
-        });
+        const response = await postRequest(path, body, headers, context, disableMessage);
+        if (response.success) {
+            navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
+        }
     }
 
     async function putAasDescriptor(aasDescriptor: descriptorTypes.AASDescriptor): Promise<void> {
@@ -107,11 +106,10 @@ export function useAASRegistryClient() {
         const body = JSON.stringify(aasDescriptor);
 
         // Send Request to upload the file
-        putRequest(path, body, headers, context, disableMessage).then((response: any) => {
-            if (response.success) {
-                navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
-            }
-        });
+        const response = await putRequest(path, body, headers, context, disableMessage);
+        if (response.success) {
+            navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
+        }
     }
 
     function createDescriptorFromAAS(

--- a/aas-web-ui/src/composables/Client/AASRepositoryClient.ts
+++ b/aas-web-ui/src/composables/Client/AASRepositoryClient.ts
@@ -95,6 +95,17 @@ export function useAASRepositoryClient() {
         return failResponse;
     }
 
+    // Fetch and Dispatch AAS from (AAS Repo)
+    async function fetchAndDispatchAasById(aasId: string) {
+        // console.log('fetchAndDispatchAasById()', aasId);
+        if (aasId.trim() === '') return;
+
+        const aas = await fetchAasById(aasId);
+        console.log('fetchAndDispatchAasById()', aasId, 'aas:', aas);
+
+        aasStore.dispatchSelectedAAS(aas);
+    }
+
     // Fetch and Dispatch AAS from (AAS Repo) Endpoint
     async function fetchAndDispatchAas(aasEndpoint: string) {
         if (aasEndpoint.trim() === '') return;
@@ -115,18 +126,17 @@ export function useAASRepositoryClient() {
         formData.append('file', aasFile);
 
         // Send Request to upload the file
-        postRequest(path, formData, headers, context, disableMessage).then((response: any) => {
-            if (response.success) {
-                navigationStore.dispatchSnackbar({
-                    status: true,
-                    timeout: 4000,
-                    color: 'success',
-                    btnColor: 'buttonText',
-                    text: 'AASX-File uploaded.',
-                }); // Show Success Snackbar
-                navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
-            }
-        });
+        const response = await postRequest(path, formData, headers, context, disableMessage);
+        if (response.success) {
+            navigationStore.dispatchSnackbar({
+                status: true,
+                timeout: 4000,
+                color: 'success',
+                btnColor: 'buttonText',
+                text: 'AASX-File uploaded.',
+            }); // Show Success Snackbar
+            navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
+        }
     }
 
     async function postAas(aas: aasTypes.AssetAdministrationShell) {
@@ -142,18 +152,17 @@ export function useAASRepositoryClient() {
         const body = JSON.stringify(jsonAas);
 
         // Send Request to upload the file
-        postRequest(path, body, headers, context, disableMessage).then((response: any) => {
-            if (response.success) {
-                navigationStore.dispatchSnackbar({
-                    status: true,
-                    timeout: 4000,
-                    color: 'success',
-                    btnColor: 'buttonText',
-                    text: 'AAS successfully created',
-                }); // Show Success Snackbar
-                navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
-            }
-        });
+        const response = await postRequest(path, body, headers, context, disableMessage);
+        if (response.success) {
+            navigationStore.dispatchSnackbar({
+                status: true,
+                timeout: 4000,
+                color: 'success',
+                btnColor: 'buttonText',
+                text: 'AAS successfully created',
+            }); // Show Success Snackbar
+            navigationStore.dispatchTriggerAASListReload(true); // Reload AAS List
+        }
     }
 
     async function putAas(aas: aasTypes.AssetAdministrationShell) {
@@ -169,17 +178,16 @@ export function useAASRepositoryClient() {
         const body = JSON.stringify(jsonAas);
 
         // Send Request to upload the file
-        putRequest(path, body, headers, context, disableMessage).then((response: any) => {
-            if (response.success) {
-                navigationStore.dispatchSnackbar({
-                    status: true,
-                    timeout: 4000,
-                    color: 'success',
-                    btnColor: 'buttonText',
-                    text: 'AAS successfully updated',
-                }); // Show Success Snackbar
-            }
-        });
+        const response = await putRequest(path, body, headers, context, disableMessage);
+        if (response.success) {
+            navigationStore.dispatchSnackbar({
+                status: true,
+                timeout: 4000,
+                color: 'success',
+                btnColor: 'buttonText',
+                text: 'AAS successfully updated',
+            }); // Show Success Snackbar
+        }
     }
 
     async function putThumbnail(thumbnail: File, aasId: string) {
@@ -201,7 +209,7 @@ export function useAASRepositoryClient() {
         const body = formData;
 
         // Send Request to upload the file
-        putRequest(path, body, headers, context, disableMessage);
+        await putRequest(path, body, headers, context, disableMessage);
     }
 
     async function getSubmodelRefsById(aasId: string): Promise<Array<any>> {
@@ -315,6 +323,7 @@ export function useAASRepositoryClient() {
         fetchAasById,
         fetchAas,
         fetchAndDispatchAas,
+        fetchAndDispatchAasById,
         uploadAas,
         postAas,
         putAas,

--- a/aas-web-ui/src/composables/Client/AASRepositoryClient.ts
+++ b/aas-web-ui/src/composables/Client/AASRepositoryClient.ts
@@ -101,7 +101,7 @@ export function useAASRepositoryClient() {
         if (aasId.trim() === '') return;
 
         const aas = await fetchAasById(aasId);
-        console.log('fetchAndDispatchAasById()', aasId, 'aas:', aas);
+        // console.log('fetchAndDispatchAasById()', aasId, 'aas:', aas);
 
         aasStore.dispatchSelectedAAS(aas);
     }


### PR DESCRIPTION
The adaptions of this PR ensure that editing of an selected AAS as well as the creation of a new AAS results in dispatching the edited/new AAS.

This PR also replaces `.then()` with the usage of `await` in AAS Clients for handling asynchronous operations.