### PR TITLE
Fix for redirect to `singleAasRedirect` URL/404 page for activated `singleAas` feature in case of invalid/not existent aasEndpoint

### DIFF
--- a/aas-web-ui/src/App.vue
+++ b/aas-web-ui/src/App.vue
@@ -76,11 +76,20 @@
 
         // Extract the aas and path Queries from the URL
         const searchParams = new URL(window.location.href).searchParams;
-        const aasEndpoint = searchParams.get('aas');
-        const submodelElementPath = searchParams.get('path');
+        const aasEndpoint = (searchParams.get('aas') || '').trim();
+        const submodelElementPath = (searchParams.get('path') || '').trim();
+
+        let aas = {} as any;
+        if (aasEndpoint) {
+            aas = await fetchAndDispatchAas(aasEndpoint);
+        }
+
+        if (aasEndpoint && submodelElementPath) {
+            await fetchAndDispatchSme(submodelElementPath, true);
+        }
 
         // Check if single AAS mode is on and no aas query is set to either redirect or show 404
-        if (envStore.getSingleAas && (aasEndpoint === null || aasEndpoint === undefined || aasEndpoint.trim() === '')) {
+        if (envStore.getSingleAas && (!aasEndpoint || aasEndpoint === '' || !aas || Object.keys(aas).length === 0)) {
             if (
                 !routesStayOnPages.includes(currentRouteName.value) &&
                 !currentRoutePath.value.startsWith('/modules/')
@@ -100,14 +109,6 @@
             handleMobileView(aasEndpoint, submodelElementPath);
         } else {
             handleDesktopView(aasEndpoint, submodelElementPath);
-        }
-
-        if (aasEndpoint) {
-            await fetchAndDispatchAas(aasEndpoint);
-        }
-
-        if (aasEndpoint && submodelElementPath) {
-            await fetchAndDispatchSme(submodelElementPath, true);
         }
     });
 

--- a/aas-web-ui/src/App.vue
+++ b/aas-web-ui/src/App.vue
@@ -80,12 +80,11 @@
         const submodelElementPath = (searchParams.get('path') || '').trim();
 
         let aas = {} as any;
-        if (aasEndpoint) {
+        if (aasEndpoint && aasEndpoint !== '') {
             aas = await fetchAndDispatchAas(aasEndpoint);
-        }
-
-        if (aasEndpoint && submodelElementPath) {
-            await fetchAndDispatchSme(submodelElementPath, true);
+            if (submodelElementPath && submodelElementPath !== '') {
+                await fetchAndDispatchSme(submodelElementPath, true);
+            }
         }
 
         // Check if single AAS mode is on and no aas query is set to either redirect or show 404
@@ -113,7 +112,7 @@
     });
 
     // Handle mobile view routing logic
-    function handleMobileView(aasEndpoint: string | null, submodelElementPath: string | null) {
+    function handleMobileView(aasEndpoint: string | null, submodelElementPath: string | null): void {
         if (currentRouteName.value && routesToAASList.includes(currentRouteName.value)) {
             // Redirect to 'AASList' with existing query parameters
             router.push({ name: 'AASList', query: route.query });
@@ -133,7 +132,7 @@
     }
 
     // Handle desktop view routing logic
-    function handleDesktopView(aasEndpoint: string | null, submodelElementPath: string | null) {
+    function handleDesktopView(aasEndpoint: string | null, submodelElementPath: string | null): void {
         const query: any = {};
         if (aasEndpoint) query.aas = aasEndpoint;
         if (submodelElementPath) query.path = submodelElementPath;

--- a/aas-web-ui/src/composables/AASHandling.ts
+++ b/aas-web-ui/src/composables/AASHandling.ts
@@ -16,18 +16,30 @@ export function useAASHandling() {
      * Fetches an Asset Administration Shell (AAS) by the provided AAS endpoint
      * and dispatches it to the AAS store.
      *
+     * @async
      * @param {string} aasEndpoint - The endpoint URL of the AAS to fetch.
+     * @returns {Promise<any>} A promise that resolves to an AAS.
      */
-    async function fetchAndDispatchAas(aasEndpoint: string): Promise<void> {
-        if (!aasEndpoint) return;
+    async function fetchAndDispatchAas(aasEndpoint: string): Promise<any> {
+        const failResponse = {};
+
+        if (!aasEndpoint) return failResponse;
 
         aasEndpoint = aasEndpoint.trim();
 
-        if (aasEndpoint === '') return;
+        if (aasEndpoint === '') return failResponse;
 
         const aas = await fetchAas(aasEndpoint);
 
+        if (!aas || Object.keys(aas).length === 0) return failResponse;
+
+        aas.isActive = true;
+
+        // TODO move router.push to AASDataStore
+        // router.push({ query: { aas: aasEndpoint } });
         aasStore.dispatchSelectedAAS(aas);
+
+        return aas;
     }
 
     /**


### PR DESCRIPTION
Closes #168

This PR fixes missing redirect for activated `singleAas` feature in case of invalid `aasEndpoint` (`aas` URL query parameter)