### PR TITLE
Fixes bug with creation of pathes for submodels

### DIFF
--- a/aas-web-ui/src/composables/AAS/SMHandling.ts
+++ b/aas-web-ui/src/composables/AAS/SMHandling.ts
@@ -221,7 +221,6 @@ export function useSMHandling() {
         }
 
         sm.timestamp = formatDate(new Date());
-        sm.path = getSmEndpointByIdFromRepo(smId);
 
         if (setDataRecursive) {
             sm = await setData({ ...sm }, sm.path, withConceptDescriptions, sm.timestamp);

--- a/aas-web-ui/src/composables/Client/SMRepositoryClient.ts
+++ b/aas-web-ui/src/composables/Client/SMRepositoryClient.ts
@@ -74,7 +74,9 @@ export function useSMRepositoryClient() {
         if (smDescriptor && Object.keys(smDescriptor).length > 0) {
             // SM Descriptor found in registry
             const smEndpoint = extractEndpointHref(smDescriptor, 'SUBMODEL-3.0');
-            return fetchSm(smEndpoint);
+            const sm = await fetchSm(smEndpoint);
+            sm.path = smEndpoint;
+            return sm;
         } else if (!smDescriptor || Object.keys(smDescriptor).length === 0) {
             const smEndpoint = getSmEndpointById(smId);
             return fetchSm(smEndpoint);


### PR DESCRIPTION
## Description of Changes

When accessing Submodels that aren't part of the configured Submodel Repo, the path of the configured Submodel Repo was incorrectly used to fetch the data for that submodel. This resulted in failing requests when trying to access "external" Submodels.

The bug was fixed by using the endpoint from the Submodel Descriptor as path property of the Submodel instead of creating the path from the configured Submodel Repo path plus the base64 URL encoded ID of the Submodel.