### PR TITLE
Work on stores

### DIFF
--- a/aas-web-ui/src/store/AASDataStore.ts
+++ b/aas-web-ui/src/store/AASDataStore.ts
@@ -1,45 +1,57 @@
 import { defineStore } from 'pinia';
 
-export const useAASStore = defineStore({
-    id: 'aasStore',
-    state: () => ({
-        aasObject: {} as any, // holds the AAS object for the currently selected AAS
-        selectedNode: {} as any, // holds the currently selected Node in the SubmodelTree/List Component
-        initTreeByReferenceElement: false, // holds the state if the SubmodelTree Component should be initialized (e.g. cause of clicking Jump-Button of a ReferenceElement)
-    }),
-    getters: {
-        getSelectedAAS: (state) => state.aasObject,
-        getSelectedNode: (state) => state.selectedNode,
-        getInitTreeByReferenceElement: (state) => state.initTreeByReferenceElement,
-    },
-    actions: {
-        dispatchSelectedAAS(aasData: any) {
-            if (
-                this.aasObject &&
-                Object.keys(this.aasObject).length > 0 &&
-                this.aasObject?.id &&
-                aasData &&
-                Object.keys(aasData).length > 0 &&
-                aasData?.id
-            ) {
-                // If existing AAS is replaced by another one, clear selectedNode
-                if (this.aasObject?.id !== aasData?.id) this.selectedNode = {};
-            }
+export const useAASStore = defineStore('aasStore', () => {
+    // States
+    const aasObject = ref({} as any); // holds the AAS object for the currently selected AAS
+    const selectedNode = ref({} as any); // holds the currently selected Node in the SubmodelTree/List Component
+    const initTreeByReferenceElement = ref(false); // holds the state if the SubmodelTree Component should be initialized (e.g. cause of clicking Jump-Button of a ReferenceElement)
 
-            if (!aasData || Object.keys(aasData).length === 0) {
-                // If empty AAS is dispatched, clear selectedNode
-                this.selectedNode = {};
-            }
+    // Getters
+    const getSelectedAAS = computed(() => aasObject.value);
+    const getSelectedNode = computed(() => selectedNode.value);
+    const getInitTreeByReferenceElement = computed(() => initTreeByReferenceElement.value);
 
-            // If the same AAS is dispatched, nothing happened with the selectedNode
+    // Actions
+    function dispatchSelectedAAS(aasValue: any): void {
+        if (
+            aasObject.value &&
+            Object.keys(aasObject.value).length > 0 &&
+            aasObject.value?.id &&
+            aasValue &&
+            Object.keys(aasValue).length > 0 &&
+            aasValue?.id
+        ) {
+            // If existing AAS is replaced by another one, clear selectedNode
+            if (aasObject.value?.id !== aasValue?.id) selectedNode.value = {};
+        }
 
-            this.aasObject = aasData;
-        },
-        dispatchSelectedNode(node: any) {
-            this.selectedNode = node;
-        },
-        dispatchInitTreeByReferenceElement(initTreeByReferenceElement: boolean) {
-            this.initTreeByReferenceElement = initTreeByReferenceElement;
-        },
-    },
+        if (!aasValue || Object.keys(aasValue).length === 0) {
+            // If empty AAS is dispatched, clear selectedNode
+            selectedNode.value = {};
+        }
+
+        // If the same AAS is dispatched, nothing happened with the selectedNode
+
+        aasObject.value = aasValue;
+    }
+
+    function dispatchSelectedNode(selectedNodeValue: any): void {
+        selectedNode.value = selectedNodeValue;
+    }
+
+    function dispatchInitTreeByReferenceElement(initTreeByReferenceElementValue: boolean): void {
+        initTreeByReferenceElement.value = initTreeByReferenceElementValue;
+    }
+
+    return {
+        // Getters
+        getSelectedAAS,
+        getSelectedNode,
+        getInitTreeByReferenceElement,
+
+        // Actions
+        dispatchSelectedAAS,
+        dispatchSelectedNode,
+        dispatchInitTreeByReferenceElement,
+    };
 });

--- a/aas-web-ui/src/store/AuthStore.ts
+++ b/aas-web-ui/src/store/AuthStore.ts
@@ -1,42 +1,63 @@
 import Keycloak from 'keycloak-js';
 import { defineStore } from 'pinia';
 
-export const useAuthStore = defineStore({
-    id: 'authStore',
-    state: () => ({
-        token: '' as string | undefined,
-        refreshToken: '' as string | undefined,
-        authStatus: false as boolean,
-        authEnabled: false as boolean,
-        keycloak: null as Keycloak | null,
-        refreshIntervalId: undefined as number | undefined,
-    }),
-    getters: {
-        getToken: (state) => state.token,
-        getRefreshToken: (state) => state.refreshToken,
-        getAuthStatus: (state) => state.authStatus,
-        getAuthEnabled: (state) => state.authEnabled,
-        getKeycloak: (state) => state.keycloak,
-        getRefreshIntervalId: (state) => state.refreshIntervalId,
-    },
-    actions: {
-        setToken(token: string | undefined) {
-            this.token = token;
-        },
-        setRefreshToken(refreshToken: string | undefined) {
-            this.refreshToken = refreshToken;
-        },
-        setAuthStatus(authStatus: boolean) {
-            this.authStatus = authStatus;
-        },
-        setAuthEnabled(authEnabled: boolean) {
-            this.authEnabled = authEnabled;
-        },
-        setKeycloak(keycloak: Keycloak | null) {
-            this.keycloak = keycloak;
-        },
-        setRefreshIntervalId(intervalId: number) {
-            this.refreshIntervalId = intervalId;
-        },
-    },
+export const useAuthStore = defineStore('authStore', () => {
+    // States
+    const token = ref('' as string | undefined);
+    const refreshToken = ref('' as string | undefined);
+    const authStatus = ref(false);
+    const authEnabled = ref(false);
+    const keycloak = ref(null as Keycloak | null);
+    const refreshIntervalId = ref(undefined as number | undefined);
+
+    // Getters
+    const getToken = computed(() => token.value);
+    const getRefreshToken = computed(() => refreshToken.value);
+    const getAuthStatus = computed(() => authStatus.value);
+    const getAuthEnabled = computed(() => authEnabled.value);
+    const getKeycloak = computed(() => keycloak.value);
+    const getRefreshIntervalId = computed(() => refreshIntervalId.value);
+
+    // Actions
+    function setToken(tokenValue: string | undefined): void {
+        token.value = tokenValue;
+    }
+
+    function setRefreshToken(refreshTokenValue: string | undefined): void {
+        refreshToken.value = refreshTokenValue;
+    }
+
+    function setAuthStatus(authStatusValue: boolean): void {
+        authStatus.value = authStatusValue;
+    }
+
+    function setAuthEnabled(authEnabledValue: boolean): void {
+        authEnabled.value = authEnabledValue;
+    }
+
+    function setKeycloak(keycloakValue: Keycloak | null): void {
+        keycloak.value = keycloakValue;
+    }
+
+    function setRefreshIntervalId(refreshIntervalIdValue: number): void {
+        refreshIntervalId.value = refreshIntervalIdValue;
+    }
+
+    return {
+        // Getters
+        getToken,
+        getRefreshToken,
+        getAuthStatus,
+        getAuthEnabled,
+        getKeycloak,
+        getRefreshIntervalId,
+
+        // Actions
+        setToken,
+        setRefreshToken,
+        setAuthStatus,
+        setAuthEnabled,
+        setKeycloak,
+        setRefreshIntervalId,
+    };
 });

--- a/aas-web-ui/src/store/EnvironmentStore.ts
+++ b/aas-web-ui/src/store/EnvironmentStore.ts
@@ -1,5 +1,4 @@
 import { defineStore } from 'pinia';
-import { computed, ref } from 'vue';
 
 const isProduction = import.meta.env.MODE === 'production';
 
@@ -144,7 +143,6 @@ export const useEnvStore = defineStore('envStore', () => {
     });
 
     return {
-        singleAas,
         getEnvBasePath,
         getEnvLogoLightPath,
         getEnvLogoDarkPath,

--- a/aas-web-ui/src/store/NavigationStore.ts
+++ b/aas-web-ui/src/store/NavigationStore.ts
@@ -14,7 +14,7 @@ import { useEnvStore } from '@/store/EnvironmentStore';
 import { stripLastCharacter } from '@/utils/StringUtils';
 
 export const useNavigationStore = defineStore('navigationStore', () => {
-    // Initialize Dependent Stores
+    // Stores
     const envStore = useEnvStore();
 
     // Composables
@@ -26,7 +26,7 @@ export const useNavigationStore = defineStore('navigationStore', () => {
     const { endpointPath: smRepoEndpointPath } = useSMRepositoryClient();
     const { endpointPath: cdRepoEndpointPath } = useCDRepositoryClient();
 
-    // Computed Property
+    // Computed Properties
     const endpointConfigAvailable = computed(() => envStore.getEndpointConfigAvailable);
     const EnvAASDiscoveryPath = computed(() => envStore.getEnvAASDiscoveryPath);
     const EnvAASRegistryPath = computed(() => envStore.getEnvAASRegistryPath);
@@ -35,7 +35,7 @@ export const useNavigationStore = defineStore('navigationStore', () => {
     const EnvSubmodelRepoPath = computed(() => envStore.getEnvSubmodelRepoPath);
     const EnvConceptDescriptionRepoPath = computed(() => envStore.getEnvConceptDescriptionRepoPath);
 
-    // State Variables
+    // States
     const drawerState = ref(true);
     const AASDiscoveryURL = ref('');
     const AASRegistryURL = ref('');

--- a/aas-web-ui/src/store/NavigationStore.ts
+++ b/aas-web-ui/src/store/NavigationStore.ts
@@ -2,7 +2,6 @@ import type { AutoSyncType, PlatformType, PluginType, SnackbarType, StatusCheckT
 import type { BaSyxComponent, BaSyxComponentKey } from '@/types/BaSyx';
 import type { LocationQuery, RouteRecordRaw } from 'vue-router';
 import { defineStore } from 'pinia';
-import { computed, reactive, ref } from 'vue';
 import { useAASDiscoveryClient } from '@/composables/Client/AASDiscoveryClient';
 import { useAASRegistryClient } from '@/composables/Client/AASRegistryClient';
 import { useAASRepositoryClient } from '@/composables/Client/AASRepositoryClient';


### PR DESCRIPTION
This PR adapts the stores:

- deletes unnecessary vue imports
- harmonizes comments
- avoids direct access to `singleAas` state
- avoids use of deprated `defineStore({})`; use of `defineStore(id, options)` instead
