### PR TITLE
Fixes for visualizations (Nameplate v2/v3 and ContactInformations)

### DIFF
--- a/aas-web-ui/src/components/Plugins/Submodels/ContactInformations_v1_0.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/ContactInformations_v1_0.vue
@@ -254,6 +254,7 @@
         semanticId: [
             'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations', // Visualization for the SMT ContactInformations
             'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation', // Visualization for the SMC ContactInformation, e.g. in the SMT Nameplate v2
+            'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/AddressInformation', // Visualization for the SMC ContactInformation, e.g. in the SMT Nameplate v3
         ],
     });
 

--- a/aas-web-ui/src/components/Plugins/Submodels/ContactInformations_v1_0.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/ContactInformations_v1_0.vue
@@ -238,7 +238,7 @@
 </template>
 
 <script lang="ts" setup>
-    import { onMounted, ref } from 'vue';
+    import { onMounted, ref, watch } from 'vue';
     import { useReferableUtils } from '@/composables/AAS/ReferableUtils';
     import { useSMHandling } from '@/composables/AAS/SMHandling';
     import { useSME } from '@/composables/AAS/SubmodelElements/SubmodelElement';
@@ -286,12 +286,24 @@
     const panel = ref(0);
     const contactInformations = ref([] as Array<any>);
 
+    //Watchers
+    watch(
+        // Watcher to ensure data is initialized in case of switching between a SM 'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations' and a SMC 'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation'
+        () => props.submodelElementData,
+        () => {
+            initializeVisualization();
+        }
+    );
+
     onMounted(() => {
         initializeVisualization();
     });
 
     async function initializeVisualization(): Promise<void> {
         loading.value = true;
+        // Reset contactInformations because it is filled by .push()
+        // Otherwise in case of switching between a SM 'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations' and a SMC 'https://admin-shell.io/zvei/nameplate/1/0/ContactInformations/ContactInformation' wrong data will be displayed
+        contactInformations.value = [];
 
         if (!props.submodelElementData || Object.keys(props.submodelElementData).length === 0) {
             contactInformations.value = [];
@@ -318,7 +330,7 @@
             });
         } else if (submodelElementData.value) {
             // For SMC ContactInformation
-            contactInformationSMCs = [submodelElementData.value];
+            contactInformationSMCs = [submodelElementData];
         }
 
         contactInformationSMCs.forEach((contactInformationSMC: any) => {

--- a/aas-web-ui/src/components/Plugins/Submodels/ContactInformations_v1_0.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/ContactInformations_v1_0.vue
@@ -56,7 +56,7 @@
                                                         "
                                                         :href="valueToDisplay(contactInformationProperty)"
                                                         target="_blank"
-                                                        class="text-caption">
+                                                        class="text-caption text-primary">
                                                         {{ valueToDisplay(contactInformationProperty) }}
                                                     </a>
                                                     <span v-else class="text-caption">{{
@@ -163,14 +163,16 @@
                                                             checkIdShort(contactInformationProperty, 'TelephoneNumber')
                                                         ">
                                                         <a
-                                                            :href="`tel:${valueToDisplay(contactInformationProperty).replaceAll(' ', '')}`">
+                                                            :href="`tel:${valueToDisplay(contactInformationProperty).replaceAll(' ', '')}`"
+                                                            class="text-caption text-primary">
                                                             {{ valueToDisplay(contactInformationProperty) }}
                                                         </a>
                                                     </template>
                                                     <template
                                                         v-else-if="checkIdShort(contactInformationProperty, 'Email')">
                                                         <a
-                                                            :href="`mailto:${valueToDisplay(contactInformationProperty)}`">
+                                                            :href="`mailto:${valueToDisplay(contactInformationProperty)}`"
+                                                            class="text-caption text-primary">
                                                             {{ valueToDisplay(contactInformationProperty) }}
                                                         </a>
                                                     </template>

--- a/aas-web-ui/src/components/Plugins/Submodels/Nameplate_v2_0.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/Nameplate_v2_0.vue
@@ -43,7 +43,7 @@
                                                     v-if="valueToDisplay(productProperty).startsWith('http')"
                                                     :href="valueToDisplay(productProperty)"
                                                     target="_blank"
-                                                    class="text-caption">
+                                                    class="text-caption text-primary">
                                                     {{ valueToDisplay(productProperty) }}
                                                 </a>
                                                 <span v-else class="text-caption">
@@ -148,7 +148,7 @@
                                                     v-if="valueToDisplay(manufacturerProperty).startsWith('http')"
                                                     :href="valueToDisplay(manufacturerProperty)"
                                                     target="_blank"
-                                                    class="text-caption">
+                                                    class="text-caption text-primary">
                                                     {{ valueToDisplay(manufacturerProperty) }}
                                                 </a>
                                                 <span v-else class="text-caption">
@@ -194,12 +194,15 @@
                                                         isMobile
                                                     ">
                                                     <a
-                                                        :href="`tel:${valueToDisplay(manufacturerProperty).replaceAll(' ', '')}`">
+                                                        :href="`tel:${valueToDisplay(manufacturerProperty).replaceAll(' ', '')}`"
+                                                        class="text-caption text-primary">
                                                         {{ valueToDisplay(manufacturerProperty) }}
                                                     </a>
                                                 </template>
                                                 <template v-else-if="checkIdShort(manufacturerProperty, 'Email')">
-                                                    <a :href="`mailto:${valueToDisplay(manufacturerProperty)}`">
+                                                    <a
+                                                        :href="`mailto:${valueToDisplay(manufacturerProperty)}`"
+                                                        class="text-caption text-primary">
                                                         {{ valueToDisplay(manufacturerProperty) }}
                                                     </a>
                                                 </template>

--- a/aas-web-ui/src/components/Plugins/Submodels/Nameplate_v3_0.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/Nameplate_v3_0.vue
@@ -43,7 +43,7 @@
                                                     v-if="valueToDisplay(productProperty).startsWith('http')"
                                                     :href="valueToDisplay(productProperty)"
                                                     target="_blank"
-                                                    class="text-caption">
+                                                    class="text-caption text-primary">
                                                     {{ valueToDisplay(productProperty) }}
                                                 </a>
                                                 <span v-else class="text-caption">
@@ -148,7 +148,7 @@
                                                     v-if="valueToDisplay(manufacturerProperty).startsWith('http')"
                                                     :href="valueToDisplay(manufacturerProperty)"
                                                     target="_blank"
-                                                    class="text-caption">
+                                                    class="text-caption text-primary">
                                                     {{ valueToDisplay(manufacturerProperty) }}
                                                 </a>
                                                 <span v-else class="text-caption">
@@ -194,12 +194,15 @@
                                                         isMobile
                                                     ">
                                                     <a
-                                                        :href="`tel:${valueToDisplay(manufacturerProperty).replaceAll(' ', '')}`">
+                                                        :href="`tel:${valueToDisplay(manufacturerProperty).replaceAll(' ', '')}`"
+                                                        class="text-caption text-primary">
                                                         {{ valueToDisplay(manufacturerProperty) }}
                                                     </a>
                                                 </template>
                                                 <template v-else-if="checkIdShort(manufacturerProperty, 'Email')">
-                                                    <a :href="`mailto:${valueToDisplay(manufacturerProperty)}`">
+                                                    <a
+                                                        :href="`mailto:${valueToDisplay(manufacturerProperty)}`"
+                                                        class="text-caption text-primary">
                                                         {{ valueToDisplay(manufacturerProperty) }}
                                                     </a>
                                                 </template>


### PR DESCRIPTION
This PR

- adapts font-color of links to primary color for Nameplate v2/v3 and ContactInformations visualization
- fixes ContactInformations visualization in case of switching between a SM ContactInformations and a SMC ContactInformation
- adds support for SMC AddressInformation of SMT Nameplate v2/v3