### PR TITLE
Adapts router links `to` in main menu

### DIFF
--- a/aas-web-ui/src/components/AppNavigation/MainMenu.vue
+++ b/aas-web-ui/src/components/AppNavigation/MainMenu.vue
@@ -12,7 +12,7 @@
                             :border="isActiveRoutePath('/')"
                             subtitle="View Asset Administration Shells"
                             title="AAS Viewer"
-                            to="/"
+                            :to="isActiveRoutePath('/') ? '' : '/'"
                             @click="closeMenu">
                             <template #prepend>
                                 <v-avatar color="surface-light" icon="custom:aasIcon" rounded>
@@ -28,7 +28,7 @@
                             :border="isActiveRoutePath('/aaseditor')"
                             subtitle="Edit Asset Administration Shells"
                             title="AAS Editor"
-                            to="/aaseditor"
+                            :to="isActiveRoutePath('/aaseditor') ? '' : '/aaseditor'"
                             @click="closeMenu">
                             <template #prepend>
                                 <v-avatar color="surface-light" icon="mdi-pencil" rounded>
@@ -43,7 +43,7 @@
                             :border="isActiveRoutePath('/submodelviewer')"
                             subtitle="View Submodels"
                             title="Submodel Viewer"
-                            to="/submodelviewer"
+                            :to="isActiveRoutePath('/submodelviewer') ? '' : '/submodelviewer'"
                             @click="closeMenu">
                             <template #prepend>
                                 <v-avatar color="surface-light" icon="mdi-group" rounded>
@@ -59,7 +59,7 @@
                             :border="isActiveRoutePath('/visu')"
                             subtitle="Visualize Submodels/Submodel Elements"
                             title="Visualization"
-                            to="/visu"
+                            :to="isActiveRoutePath('/visu') ? '' : '/visu'"
                             @click="closeMenu">
                             <template #prepend>
                                 <v-avatar color="surface-light" icon="mdi-chart-line" rounded>
@@ -113,7 +113,12 @@
                 </v-row>
             </v-container>
             <template #actions>
-                <v-btn class="text-none" color="primary" text="About" to="/about" @click="closeMenu" />
+                <v-btn
+                    class="text-none"
+                    color="primary"
+                    text="About"
+                    :to="isActiveRoutePath('/about') ? '' : '/about'"
+                    @click="closeMenu" />
 
                 <v-divider inset vertical />
 


### PR DESCRIPTION
This PR fixes/adapts the router links `to` in the main menu.

Before this PR there was the following bug:
1) Being in the AAS Viewer for example
2) Click (again) on the main menu item "AAS Viewer" leads to removing the aas query parameter and therefor to the 404 page respectivley to the `SINGLE_AAS_REDIRECT` page