### PR TITLE
Fixes for ConceptDescriptions

### DIFF
--- a/aas-web-ui/src/components/SubmodelElementView.vue
+++ b/aas-web-ui/src/components/SubmodelElementView.vue
@@ -156,9 +156,7 @@
                     </v-expansion-panel-title>
                     <v-divider v-if="expandedCdIndex === index"></v-divider>
                     <v-expansion-panel-text class="pa-0 ma-0">
-                        <ConceptDescription
-                            :concept-description-object="conceptDescription"
-                            class="mt-2"></ConceptDescription>
+                        <ConceptDescription :concept-description-object="conceptDescription"></ConceptDescription>
                     </v-expansion-panel-text>
                 </v-expansion-panel>
             </v-expansion-panels>

--- a/aas-web-ui/src/composables/AAS/ConceptDescriptionHandling.ts
+++ b/aas-web-ui/src/composables/AAS/ConceptDescriptionHandling.ts
@@ -173,8 +173,6 @@ export function useConceptDescriptionHandling() {
                 conceptDescription && Object.keys(conceptDescription).length !== 0 && !Array.isArray(conceptDescription)
         );
 
-        console.log('fetched conceptDescriptions', conceptDescriptions);
-
         return conceptDescriptions;
     }
 

--- a/aas-web-ui/src/composables/AAS/ConceptDescriptionHandling.ts
+++ b/aas-web-ui/src/composables/AAS/ConceptDescriptionHandling.ts
@@ -167,9 +167,13 @@ export function useConceptDescriptionHandling() {
 
         let conceptDescriptions = await Promise.all(cdPromises);
 
+        // Filter empty objects and errors
         conceptDescriptions = conceptDescriptions.filter(
-            (conceptDescription: any) => Object.keys(conceptDescription).length !== 0
-        ); // Filter empty Objects
+            (conceptDescription: any) =>
+                conceptDescription && Object.keys(conceptDescription).length !== 0 && !Array.isArray(conceptDescription)
+        );
+
+        console.log('fetched conceptDescriptions', conceptDescriptions);
 
         return conceptDescriptions;
     }


### PR DESCRIPTION
## Description of Changes

This PR

1. fixes a small design glitch (not needed margin):
<img width="592" alt="2025_06_19_06_48_34_AAS_UI" src="https://github.com/user-attachments/assets/3a453ad0-4387-437b-9857-0377e915557e" />

2. fixes the display of empty CDs (e.g. caused by error response from CD repo):
<img width="945" alt="2025-06-19 06_53_21-AAS UI" src="https://github.com/user-attachments/assets/5e01e293-0117-46b2-b631-0c990e36d895" />
