### PR TITLE
Fixes problem with file uploads

### DIFF
--- a/aas-web-ui/src/components/SubmodelElements/File.vue
+++ b/aas-web-ui/src/components/SubmodelElements/File.vue
@@ -215,16 +215,20 @@
             },
 
             // Function to upload a File
-            uploadFile() {
+            async uploadFile() {
                 // console.log("Upload File: ", this.newFile);
                 // check if a file is selected
                 if (this.newFile.length == 0) return;
 
-                this.putAttachmentFile(this.newFile, this.SelectedNode.path).then((response: any) => {
+                try {
+                    const response = await this.putAttachmentFile(this.newFile, this.SelectedNode.path);
                     if (response) {
-                        location.reload(); // reload the page to update the file preview
+                        await this.fetchAndDispatchSme(this.SelectedNode.path, false);
+                        this.newFile = [];
                     }
-                });
+                } catch (error) {
+                    console.error('Error uploading file:', error);
+                }
             },
 
             // Function to set the focus on the input field


### PR DESCRIPTION
## Description of Changes

This PR fixes a bug that caused 502 error pages in the browser when a file upload was attempted.
The reason was the `location.reload()` call that caused trouble when Keycloak was active.

To solve the problem, the reload was removed and replaced by triggering the internal reactivity by dispatching the currently selected file again.