### PR TITLE
Fixes File Upload implementations

### DIFF
--- a/aas-web-ui/src/composables/Client/AASRepositoryClient.ts
+++ b/aas-web-ui/src/composables/Client/AASRepositoryClient.ts
@@ -378,11 +378,11 @@ export function useAASRepositoryClient() {
         // Create formData
         const formData = new FormData();
         formData.append('file', thumbnail);
+        formData.append('fileName', thumbnail.name);
 
         const context = 'uploading thumbnail';
         const disableMessage = false;
-        const path =
-            aasRepoUrl + '/' + base64Encode(aasId) + '/asset-information/thumbnail' + '?fileName=' + thumbnail.name;
+        const path = aasRepoUrl + '/' + base64Encode(aasId) + '/asset-information/thumbnail';
         const headers = new Headers();
         const body = formData;
 

--- a/aas-web-ui/src/composables/Client/SMRepositoryClient.ts
+++ b/aas-web-ui/src/composables/Client/SMRepositoryClient.ts
@@ -385,10 +385,11 @@ export function useSMRepositoryClient() {
         // Create formData
         const formData = new FormData();
         formData.append('file', file);
+        formData.append('fileName', file.name);
 
         const context = 'uploading file attachment';
         const disableMessage = false;
-        const requestPath = path + '/attachment' + '?fileName=' + file.name;
+        const requestPath = path + '/attachment';
         const headers = new Headers();
         const body = formData;
 


### PR DESCRIPTION
## Description of Changes

The `/asset-information/thumbnail` and the `/attachment` endpoints got updated to provide the `fileName` as part of the formData instead of a query parameter.

## Related Issue

This fixes the conformance issue towards the AAS specification, where it is required to provide the fileName as part of the formData.