### PR TITLE
Fix jumping for SME Entity

### DIFF
--- a/aas-web-ui/src/components/SubmodelElements/Entity.vue
+++ b/aas-web-ui/src/components/SubmodelElements/Entity.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script lang="ts" setup>
-    import { onMounted, Ref, ref } from 'vue';
+    import { onMounted, Ref, ref, watch } from 'vue';
     import { useAASHandling } from '@/composables/AAS/AASHandling';
     import { useAASDiscoveryClient } from '@/composables/Client/AASDiscoveryClient';
     import { useClipboardUtil } from '@/composables/ClipboardUtil';
@@ -102,6 +102,23 @@
     const getCopyIconAsRef = (): Ref => {
         return copyIcon;
     };
+
+    // Watchers
+    watch(
+        () => props.entityObject,
+        () => {
+            if (props.entityObject.globalAssetId) {
+                checkAndSetDisabledState(props.entityObject.globalAssetId);
+                loadingStates.value[props.entityObject.globalAssetId] = false;
+            }
+            if (props.entityObject.specificAssetIds) {
+                props.entityObject.specificAssetIds.forEach((specificAssetId: any) => {
+                    checkAndSetDisabledState(specificAssetId.name);
+                    loadingStates.value[specificAssetId.name] = false;
+                });
+            }
+        }
+    );
 
     onMounted(() => {
         // initialize disabledStates, loadingStates and


### PR DESCRIPTION
## Description of Changes

This PR fixes a problem with the jumping functionality of a SME Entity.

If a SME Entity is selected and another SME Entity is selected afterwards, the jumping does not work cause checkAndSetDisabledState() was not executed after the (second) SME Entity selection (missing props watcher).