### PR TITLE
Add support for deletion of AAS & Submodels only stored in Repositories

### DIFF
--- a/aas-web-ui/src/utils/AAS/DescriptorUtils.ts
+++ b/aas-web-ui/src/utils/AAS/DescriptorUtils.ts
@@ -1,11 +1,11 @@
 /**
  * Extracts the endpoint from a descriptor based on the given interface short name.
  *
- * @param {Object} descriptor - The descriptor containing endpoint information.
+ * @param {Object} descriptor_or_model - The descriptor or model (AAS / Submodel) containing endpoint information.
  * @param {string} interfaceShortName - The short name of the interface to match against endpoint interfaces.
  * @returns {string} The href of the matching endpoint's protocol information if found, otherwise an empty string.
  */
-export function extractEndpointHref(descriptor: any, interfaceShortName: string): string {
+export function extractEndpointHref(descriptor_or_model: any, interfaceShortName: string): string {
     const failResponse = '';
 
     const interfaceShortNames = [
@@ -22,6 +22,14 @@ export function extractEndpointHref(descriptor: any, interfaceShortName: string)
         'AAS-DISCOVERY',
     ];
 
+    if (
+        (descriptor_or_model?.modelType == 'AssetAdministrationShell' ||
+            descriptor_or_model?.modelType == 'Submodel') &&
+        descriptor_or_model?.path
+    ) {
+        return descriptor_or_model.path;
+    }
+
     if (!interfaceShortName || interfaceShortName.trim() === '') return failResponse;
 
     interfaceShortName = interfaceShortName.trim();
@@ -31,11 +39,11 @@ export function extractEndpointHref(descriptor: any, interfaceShortName: string)
         return failResponse;
     }
 
-    if (!Array.isArray(descriptor?.endpoints) || descriptor?.endpoints.length === 0) {
+    if (!Array.isArray(descriptor_or_model?.endpoints) || descriptor_or_model?.endpoints.length === 0) {
         return failResponse;
     }
 
-    const endpoints = descriptor.endpoints;
+    const endpoints = descriptor_or_model.endpoints;
 
     // find the right endpoint based on the interfaceShortName (has to match endpoint.interface)
     const endpoint = endpoints.find((endpoint: any) => {


### PR DESCRIPTION
# Pull Request Template

## Description of Changes

If there is an AAS or a Submodel not stored inside a registry / no registry configured, BaSyx Web UI cannot delete this AAS / this Submodel.
With this change a small piece of logic is added, that automatically extracts the correct path to the Submodel / AAS, see `extractEndpointHref` funciton in `DescriptorUtils.ts`.
And then handle Submodels / AAS deletion differntly if no Registry is configured, see `DeleteAAS.vue`.

## Related Issue

I did not create an issue ticket, rather I just went ahead and fixed the bug, where Submodels and AAS couldn't be deleted if no registry was configured.

## BaSyx Configuration for Testing

Start BaSyx Web UI and only configure AAS and SM Repository and not the respective Registries.

## AAS Files Used for Testing

not needed

## Additional Information


All test ran through, and I encountered no error, but would love the opinion of someone involved more in the project.


