### PR TITLE
Removes import of compiler macros `defineEmits` and `defineProps`

### DIFF
--- a/aas-web-ui/src/pages/modules/CompanyDataPortal/components/BankAccountForm.vue
+++ b/aas-web-ui/src/pages/modules/CompanyDataPortal/components/BankAccountForm.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-    import { computed, defineEmits, defineProps } from 'vue';
+    import { computed } from 'vue';
     import FormField from './FormField.vue';
 
     const props = defineProps<{


### PR DESCRIPTION
Compiler macros no longer needs to be imported