### PR TITLE
Fixes problem with json insert error not correctly showing

### DIFF
--- a/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
+++ b/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
@@ -365,7 +365,7 @@
                 btnColor: 'buttonText',
                 text: 'Error copied to clipboard',
             });
-        } catch (error) {
+        } catch {
             navigationStore.dispatchSnackbar({
                 status: true,
                 timeout: 4000,

--- a/aas-web-ui/src/components/EditorComponents/JsonInsert.vue
+++ b/aas-web-ui/src/components/EditorComponents/JsonInsert.vue
@@ -135,7 +135,7 @@
                 timeout: 20000,
                 color: 'error',
                 btnColor: 'buttonText',
-                baseError: instanceOrError.error.message,
+                baseError: instanceOrError.error?.message || String(instanceOrError.error),
                 extendedError: instanceOrError.error.path ? JSON.stringify(instanceOrError.error.path, null, 2) : '',
             });
             return;


### PR DESCRIPTION
## Description of Changes

This PR fixes a problem where error messages where just shown as [object, object] when uploading Submodels/SubmodelElements from JSON.

This PR also adds a copy button to copy the base and extended error to the clipboard