### PR TITLE
Fixes Redirects when Base Path is configured

### DIFF
--- a/aas-web-ui/src/composables/Auth/useAuth.ts
+++ b/aas-web-ui/src/composables/Auth/useAuth.ts
@@ -182,7 +182,10 @@ export function useAuth(router?: Router) {
                 }
 
                 logoutUrl = new URL(endSessionEndpoint);
-                logoutUrl.searchParams.set('post_logout_redirect_uri', window.location.origin + '/');
+                logoutUrl.searchParams.set(
+                    'post_logout_redirect_uri',
+                    window.location.origin + window.location.pathname
+                );
 
                 // Add id_token_hint if available (required by some OAuth2 providers)
                 const idToken = infra.token?.idToken;

--- a/aas-web-ui/src/composables/Auth/useOAuth2Form.ts
+++ b/aas-web-ui/src/composables/Auth/useOAuth2Form.ts
@@ -188,7 +188,7 @@ export function useOAuth2Form(): {
                 await initiateOAuth2AuthorizationCodeFlow({
                     authorizationEndpoint,
                     clientId: formData.value.clientId,
-                    redirectUri: `${window.location.origin}/`,
+                    redirectUri: `${window.location.origin}${window.location.pathname}`,
                     scope: formData.value.scope || 'openid profile email',
                     state,
                 });

--- a/aas-web-ui/src/pages/modules/PcfProcess/PcfProductSelection.vue
+++ b/aas-web-ui/src/pages/modules/PcfProcess/PcfProductSelection.vue
@@ -207,7 +207,7 @@
     }
 
     function getHref(shell: any): string {
-        return `${window.location.origin}?aas=${shell.path}`;
+        return `${window.location.origin}${window.location.pathname}?aas=${shell.path}`;
     }
 
     function produce(): void {

--- a/aas-web-ui/src/router.ts
+++ b/aas-web-ui/src/router.ts
@@ -255,7 +255,7 @@ export async function createAppRouter(): Promise<Router> {
                     const tokenData = await exchangeOAuth2AuthorizationCode({
                         tokenEndpoint,
                         clientId: infrastructure.auth.oauth2.clientId,
-                        redirectUri: `${window.location.origin}${to.path}`,
+                        redirectUri: `${window.location.origin}${window.location.pathname}`,
                         code,
                         state, // Pass state to retrieve correct code verifier
                     });

--- a/aas-web-ui/src/utils/InfrastructureUtils.ts
+++ b/aas-web-ui/src/utils/InfrastructureUtils.ts
@@ -36,7 +36,7 @@ export function requiredRule(value: string): string | boolean {
  * Get OAuth2 redirect URI for the current application
  */
 export function getRedirectUri(): string {
-    return `${window.location.origin}/oauth2/callback`;
+    return `${window.location.origin}${window.location.pathname}/oauth2/callback`;
 }
 
 /**


### PR DESCRIPTION
## Description of Changes
This pull request updates how redirect URIs are constructed throughout the application to use the current page's full path instead of just the origin or a hardcoded path. This ensures that OAuth2 flows and deep linking work correctly, preserving the user's current location during authentication and navigation.

**Authentication and OAuth2 flow improvements:**

* Updated the `post_logout_redirect_uri` and `redirectUri` parameters in authentication-related functions to use `window.location.pathname` in addition to `window.location.origin`, ensuring users are redirected back to their current path after logout or authentication. [[1]](diffhunk://#diff-9cc60870c8cadec874ac84da07914ce77f0022c0ea8b7fcb51cd4878ccc0ce7dL185-R188) [[2]](diffhunk://#diff-41380311823a99841df28ad4c4204e5840e7290a9b200b271816c58f25878f51L191-R191) [[3]](diffhunk://#diff-b5edd26dde05a8db76538634d17152fd89e119d9fd6d6183d68afc024419e24bL258-R258) [[4]](diffhunk://#diff-7d9f16ad2adcae9eb83c90ffbc2ba28250f8ea0a9e65d27fce32c77ae06b3780L39-R39)

**Link generation consistency:**

* Modified the `getHref` function in `PcfProductSelection.vue` to include `window.location.pathname` when generating links, supporting correct deep linking within the app.
