### PR TITLE
Fixes reactivity issue in BoM Plugin

### DIFF
--- a/aas-web-ui/src/components/EditorComponents/DeleteDialog.vue
+++ b/aas-web-ui/src/components/EditorComponents/DeleteDialog.vue
@@ -3,7 +3,7 @@
         <v-card>
             <v-card-title> Confirm Delete </v-card-title>
             <v-divider></v-divider>
-            <v-card-text class="pb-0">
+            <v-card-text v-if="element" class="pb-0">
                 <span>Are you sure you want to delete the </span>
                 <span class="font-weight-bold">{{ element.modelType }}</span>
                 <span> with the</span>

--- a/aas-web-ui/src/components/Plugins/Submodels/HierarchicalStructures_v1_x.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/HierarchicalStructures_v1_x.vue
@@ -1095,6 +1095,7 @@
                     text: `RelationshipElement '${selectedRelationshipType.value.label}' ${isEditing ? 'updated' : 'created'} successfully`,
                 });
                 // Refresh the visualization
+                navigationStore.dispatchTriggerTreeviewReload();
                 fetchAndDispatchSm(props.submodelElementData.path as string);
             } else {
                 navigationStore.dispatchSnackbar({


### PR DESCRIPTION
This pull request introduces improvements to the user interface for deleting elements and enhances the behavior of the hierarchical structures plugin. The main changes ensure that the delete confirmation dialog only appears when an element is selected, and that the tree view visualization is refreshed after creating or updating a relationship element.

User Interface Improvements:

* The delete confirmation dialog in `DeleteDialog.vue` now only displays its content if an `element` is present, preventing errors or confusing UI when no element is selected.

Plugin Behavior Enhancements:

* After creating or updating a relationship element in `HierarchicalStructures_v1_x.vue`, the tree view is now explicitly reloaded to reflect the latest changes.