### PR TITLE
Improves infrastructure token refresh handling

### DIFF
--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureAuth.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureAuth.ts
@@ -8,7 +8,7 @@ export function useInfrastructureAuth(): {
     refreshInfrastructureTokens: (
         infrastructures: InfrastructureConfig[],
         infrastructureId?: string
-    ) => Promise<Array<{ infraName: string; error: string }>>;
+    ) => Promise<Array<{ infraId: string; infraName: string; error: string }>>;
     setAuthenticationStatusForInfrastructure: (
         infrastructures: InfrastructureConfig[],
         infrastructureId: string,
@@ -25,8 +25,8 @@ export function useInfrastructureAuth(): {
     async function refreshInfrastructureTokens(
         infrastructures: InfrastructureConfig[],
         infrastructureId?: string
-    ): Promise<Array<{ infraName: string; error: string }>> {
-        const failures: Array<{ infraName: string; error: string }> = [];
+    ): Promise<Array<{ infraId: string; infraName: string; error: string }>> {
+        const failures: Array<{ infraId: string; infraName: string; error: string }> = [];
         const TOKEN_REFRESH_BUFFER = 5 * 60 * 1000; // 5 minutes in milliseconds
         const now = Date.now();
 
@@ -75,6 +75,7 @@ export function useInfrastructureAuth(): {
                         continue;
                     }
                     failures.push({
+                        infraId: infrastructure.id,
                         infraName: infrastructure.name,
                         error: 'No refresh token available - re-authentication required',
                     });
@@ -85,6 +86,7 @@ export function useInfrastructureAuth(): {
                 else if (auth.securityType === 'OAuth2') {
                     if (!auth.oauth2) {
                         failures.push({
+                            infraId: infrastructure.id,
                             infraName: infrastructure.name,
                             error: 'Missing OAuth2 configuration',
                         });
@@ -139,6 +141,7 @@ export function useInfrastructureAuth(): {
                 }
             } catch (error) {
                 failures.push({
+                    infraId: infrastructure.id,
                     infraName: infrastructure.name,
                     error: error instanceof Error ? error.message : 'Unknown error',
                 });

--- a/aas-web-ui/src/store/InfrastructureStore.ts
+++ b/aas-web-ui/src/store/InfrastructureStore.ts
@@ -463,7 +463,7 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
     // Wrapper functions that delegate to auth composable
     async function refreshInfrastructureTokens(
         infrastructureId?: string
-    ): Promise<Array<{ infraName: string; error: string }>> {
+    ): Promise<Array<{ infraId: string; infraName: string; error: string }>> {
         const failures = await infrastructureAuth.refreshInfrastructureTokens(infrastructures.value, infrastructureId);
 
         // Save updated tokens to storage if any were refreshed


### PR DESCRIPTION
This pull request refines the token refresh logic for infrastructures by making error handling more precise and improving user notifications. The main changes involve tracking failures by infrastructure ID, updating the notification logic to only alert for the selected infrastructure, and ensuring error objects include infrastructure identifiers.

**Token refresh and error handling improvements:**

* The `refreshInfrastructureTokens` function in `App.vue` now refreshes tokens for all infrastructures but only notifies the user about failures for the selected infrastructure, making notifications more relevant and less noisy.
* Failure objects returned by token refresh operations now include the `infraId` field, allowing errors to be associated with specific infrastructures. This change is reflected in both the composable (`useInfrastructureAuth.ts`) and store (`InfrastructureStore.ts`). [[1]](diffhunk://#diff-24c42172f9a4c4e2f16d1cc9fd528c3435cf5b68907698e496c27fef39105847L11-R11) [[2]](diffhunk://#diff-e895afc976eef65252b91ddc86925c205e34b4baf47e475806ffafdf86f18dcbL466-R466)
* All places where failures are pushed during token refresh (missing token, missing OAuth2 config, and caught errors) now include the `infraId` property, ensuring consistent error structure. [[1]](diffhunk://#diff-24c42172f9a4c4e2f16d1cc9fd528c3435cf5b68907698e496c27fef39105847R78) [[2]](diffhunk://#diff-24c42172f9a4c4e2f16d1cc9fd528c3435cf5b68907698e496c27fef39105847R89) [[3]](diffhunk://#diff-24c42172f9a4c4e2f16d1cc9fd528c3435cf5b68907698e496c27fef39105847R144)
* The function signature and return type for `refreshInfrastructureTokens` have been updated across the codebase to include `infraId` in the failure object, ensuring type consistency.