### PR TITLE
Adds Qualifiers to the AAS Editor

### DIFF
--- a/aas-web-ui/src/components.d.ts
+++ b/aas-web-ui/src/components.d.ts
@@ -99,6 +99,7 @@ declare module 'vue' {
     Property: typeof import('./components/SubmodelElements/Property.vue')['default']
     PropertyForm: typeof import('./components/EditorComponents/SubmodelElements/PropertyForm.vue')['default']
     QualifierElement: typeof import('./components/UIComponents/QualifierElement.vue')['default']
+    QualifierInput: typeof import('./components/EditorComponents/InputTypes/QualifierInput.vue')['default']
     Range: typeof import('./components/SubmodelElements/Range.vue')['default']
     RangeForm: typeof import('./components/EditorComponents/SubmodelElements/RangeForm.vue')['default']
     RangeInput: typeof import('./components/EditorComponents/InputTypes/RangeInput.vue')['default']

--- a/aas-web-ui/src/components/EditorComponents/InputTypes/QualifierInput.vue
+++ b/aas-web-ui/src/components/EditorComponents/InputTypes/QualifierInput.vue
@@ -1,0 +1,156 @@
+<template>
+    <v-sheet v-for="(qualifier, index) in qualifiersValue ?? []" :key="index" class="mb-4" border rounded>
+        <v-card-actions class="bg-cardHeader">
+            <div class="ml-2">Qualifier {{ index + 1 }}</div>
+            <v-spacer></v-spacer>
+            <v-btn
+                prepend-icon="mdi-delete"
+                variant="text"
+                text="Remove Qualifier"
+                class="text-none"
+                @click="removeQualifier(index)"></v-btn>
+        </v-card-actions>
+        <v-divider></v-divider>
+        <v-card-text class="pt-7">
+            <v-row align="center">
+                <v-col class="py-0">
+                    <TextInput v-model="qualifier.type" label="Type" />
+                </v-col>
+            </v-row>
+
+            <v-row align="center">
+                <v-col class="py-0">
+                    <SelectInput v-model="qualifier.valueType" label="Value Type" type="dataType" :clearable="false" />
+                </v-col>
+            </v-row>
+
+            <v-row align="center">
+                <v-col class="py-0">
+                    <TextInput v-model="qualifier.value" label="Value" />
+                </v-col>
+            </v-row>
+
+            <v-row align="center">
+                <v-col class="py-0">
+                    <SelectInput v-model="qualifier.kind" label="Kind" type="qualifierKind" :clearable="true" />
+                </v-col>
+            </v-row>
+
+            <v-row align="center">
+                <v-col class="py-0">
+                    <v-divider></v-divider>
+                    <v-list-item class="pl-0 pt-0">
+                        <template #title>
+                            <div class="text-subtitle-2">Semantic ID</div>
+                        </template>
+                    </v-list-item>
+                    <v-btn
+                        v-if="qualifier.semanticId === null"
+                        color="primary"
+                        prepend-icon="mdi-plus"
+                        variant="outlined"
+                        text="Add Semantic ID"
+                        class="text-none mt-1 mb-4"
+                        @click="addSemanticId(index)"></v-btn>
+                    <ReferenceInput v-else v-model="qualifier.semanticId" label="Semantic ID" :no-header="true" />
+                </v-col>
+            </v-row>
+
+            <v-row align="center">
+                <v-col class="py-0">
+                    <v-divider></v-divider>
+                    <v-list-item class="pl-0 pt-0">
+                        <template #title>
+                            <div class="text-subtitle-2">Value ID</div>
+                        </template>
+                    </v-list-item>
+                    <v-btn
+                        v-if="qualifier.valueId === null"
+                        color="primary"
+                        prepend-icon="mdi-plus"
+                        variant="outlined"
+                        text="Add Value ID"
+                        class="text-none mt-1 mb-4"
+                        @click="addValueId(index)"></v-btn>
+                    <ReferenceInput v-else v-model="qualifier.valueId" label="Value ID" :no-header="true" />
+                </v-col>
+            </v-row>
+        </v-card-text>
+    </v-sheet>
+
+    <v-btn
+        color="primary"
+        prepend-icon="mdi-plus"
+        variant="outlined"
+        text="Add Qualifier"
+        class="text-none mt-1 mb-4"
+        @click="addQualifier"></v-btn>
+</template>
+
+<script setup lang="ts">
+    import { types as aasTypes } from '@aas-core-works/aas-core3.1-typescript';
+    import { ref, watch } from 'vue';
+
+    const props = defineProps<{
+        modelValue: Array<aasTypes.Qualifier> | null;
+    }>();
+
+    const emit = defineEmits<{
+        (event: 'update:modelValue', value: Array<aasTypes.Qualifier> | null): void;
+    }>();
+
+    const qualifiersValue = ref<Array<aasTypes.Qualifier> | null>(props.modelValue);
+
+    watch(
+        qualifiersValue,
+        (newValue) => {
+            emit('update:modelValue', newValue);
+        },
+        { deep: true }
+    );
+
+    watch(
+        () => props.modelValue,
+        (newValue) => {
+            qualifiersValue.value = newValue;
+        }
+    );
+
+    function addQualifier(): void {
+        if (qualifiersValue.value === null) {
+            qualifiersValue.value = [];
+        }
+        qualifiersValue.value.push(new aasTypes.Qualifier('', aasTypes.DataTypeDefXsd.String));
+    }
+
+    function removeQualifier(index: number): void {
+        if (qualifiersValue.value === null) {
+            return;
+        }
+
+        qualifiersValue.value.splice(index, 1);
+        if (qualifiersValue.value.length === 0) {
+            qualifiersValue.value = null;
+        }
+    }
+
+    function addSemanticId(index: number): void {
+        if (qualifiersValue.value === null || !qualifiersValue.value[index]) {
+            return;
+        }
+
+        qualifiersValue.value[index].semanticId = new aasTypes.Reference(aasTypes.ReferenceTypes.ExternalReference, [
+            new aasTypes.Key(aasTypes.KeyTypes.GlobalReference, ''),
+        ]);
+    }
+
+    function addValueId(index: number): void {
+        if (qualifiersValue.value === null || !qualifiersValue.value[index]) {
+            return;
+        }
+
+        qualifiersValue.value[index].valueId = new aasTypes.Reference(aasTypes.ReferenceTypes.ExternalReference, [
+            new aasTypes.Key(aasTypes.KeyTypes.GlobalReference, ''),
+        ]);
+    }
+</script>

--- a/aas-web-ui/src/components/EditorComponents/InputTypes/SelectInput.vue
+++ b/aas-web-ui/src/components/EditorComponents/InputTypes/SelectInput.vue
@@ -21,6 +21,7 @@
         dataType: aasTypes.DataTypeDefXsd;
         elementType: aasTypes.AasSubmodelElements;
         entityType: aasTypes.EntityType;
+        qualifierKind: aasTypes.QualifierKind;
     };
 
     type ValueType<T extends keyof ValueMap> = ValueMap[T];
@@ -95,6 +96,12 @@
                 return [
                     { title: 'Co-Managed Entity', value: aasTypes.EntityType.CoManagedEntity },
                     { title: 'Self-Managed Entity', value: aasTypes.EntityType.SelfManagedEntity },
+                ];
+            case 'qualifierKind':
+                return [
+                    { title: 'ValueQualifier', value: aasTypes.QualifierKind.ValueQualifier },
+                    { title: 'ConceptQualifier', value: aasTypes.QualifierKind.ConceptQualifier },
+                    { title: 'TemplateQualifier', value: aasTypes.QualifierKind.TemplateQualifier },
                 ];
             default:
                 return [];

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/AnnotatedRelationshipElementForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/AnnotatedRelationshipElementForm.vue
@@ -107,8 +107,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -168,6 +175,7 @@
     const annotatedRelationshipElementCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     const firstReference = ref<aasTypes.Reference | null>(null);
     const secondReference = ref<aasTypes.Reference | null>(null);
 
@@ -228,6 +236,14 @@
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
                     border += ' border-t-thin';
                 }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-t-thin';
+                }
                 break;
         }
         return border;
@@ -278,6 +294,7 @@
         }
 
         annotatedRelationshipElementObject.value.category = annotatedRelationshipElementCategory.value;
+        annotatedRelationshipElementObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(annotatedRelationshipElementObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {
@@ -378,6 +395,7 @@
         description.value = null;
         annotatedRelationshipElementCategory.value = null;
         semanticId.value = null;
+        qualifiers.value = null;
         firstReference.value = null;
         secondReference.value = null;
         openPanels.value = [0, 1];
@@ -404,6 +422,7 @@
             description.value = annotatedRelationshipElementObject.value.description ?? null;
             annotatedRelationshipElementCategory.value = annotatedRelationshipElementObject.value.category ?? null;
             semanticId.value = annotatedRelationshipElementObject.value.semanticId ?? null;
+            qualifiers.value = annotatedRelationshipElementObject.value.qualifiers ?? null;
             firstReference.value = annotatedRelationshipElementObject.value.first ?? null;
             secondReference.value = annotatedRelationshipElementObject.value.second ?? null;
         }

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/BlobForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/BlobForm.vue
@@ -94,8 +94,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -166,6 +173,7 @@ usage of the 'Enter' key, make sure to edit the keyDown/keyUp method to not exec
     const contentType = ref<string>('application/unknown');
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
 
     const errors = ref<Map<string, string>>(new Map());
 
@@ -222,6 +230,14 @@ usage of the 'Enter' key, make sure to edit the keyDown/keyUp method to not exec
                 break;
             case 3:
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-t-thin';
+                }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
                     border += 'border-t-thin';
                 }
                 break;
@@ -237,6 +253,7 @@ usage of the 'Enter' key, make sure to edit the keyDown/keyUp method to not exec
         blobContent.value = null;
         contentType.value = 'application/unknown';
         semanticId.value = null;
+        qualifiers.value = null;
         openPanels.value = [0, 1];
     }
 
@@ -262,6 +279,7 @@ usage of the 'Enter' key, make sure to edit the keyDown/keyUp method to not exec
             blobContent.value = blobObject.value.value ?? null;
             contentType.value = blobObject.value.contentType ?? 'application/unknown';
             semanticId.value = blobObject.value.semanticId ?? null;
+            qualifiers.value = blobObject.value.qualifiers ?? null;
         }
     }
 
@@ -317,6 +335,7 @@ usage of the 'Enter' key, make sure to edit the keyDown/keyUp method to not exec
         }
 
         blobObject.value.category = blobCategory.value;
+        blobObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(blobObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/CollectionForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/CollectionForm.vue
@@ -76,8 +76,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(2)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(2)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -138,6 +145,7 @@
     const smcCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     //const smcValue = ref<string | null>(null);
 
     const errors = ref<Map<string, string>>(new Map());
@@ -189,6 +197,14 @@
                 if (openPanels.value.includes(1) || openPanels.value.includes(2)) {
                     border += ' border-t-thin';
                 }
+                if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 3:
+                if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-t-thin';
+                }
                 break;
         }
         return border;
@@ -235,6 +251,7 @@
         }
 
         smcObject.value.category = smcCategory.value;
+        smcObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(smcObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {
@@ -331,6 +348,7 @@
         description.value = null;
         smcCategory.value = null;
         semanticId.value = null;
+        qualifiers.value = null;
         openPanels.value = [0];
     }
 
@@ -353,6 +371,7 @@
             description.value = smcObject.value.description ?? null;
             smcCategory.value = smcObject.value.category ?? null;
             semanticId.value = smcObject.value.semanticId ?? null;
+            qualifiers.value = smcObject.value.qualifiers ?? null;
         }
     }
 </script>

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/EntityForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/EntityForm.vue
@@ -95,8 +95,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -156,6 +163,7 @@
     const entityCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
 
     const entityType = ref<aasTypes.EntityType>(aasTypes.EntityType.SelfManagedEntity);
     const globalAssetId = ref<string | null>(null);
@@ -218,6 +226,14 @@
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
                     border += ' border-t-thin';
                 }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-t-thin';
+                }
                 break;
         }
         return border;
@@ -266,6 +282,7 @@
         }
 
         entityObject.value.category = entityCategory.value;
+        entityObject.value.qualifiers = qualifiers.value;
 
         if (globalAssetId.value !== null && globalAssetId.value !== '') {
             entityObject.value.globalAssetId = globalAssetId.value;
@@ -377,6 +394,7 @@
         entityType.value = aasTypes.EntityType.SelfManagedEntity;
         globalAssetId.value = null;
         specificAssetIds.value = null;
+        qualifiers.value = null;
         openPanels.value = [0, 1];
     }
 
@@ -402,6 +420,7 @@
             entityType.value = entityObject.value.entityType ?? aasTypes.EntityType.SelfManagedEntity;
             globalAssetId.value = entityObject.value.globalAssetId ?? null;
             specificAssetIds.value = entityObject.value.specificAssetIds ?? null;
+            qualifiers.value = entityObject.value.qualifiers ?? null;
         }
     }
 </script>

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/FileForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/FileForm.vue
@@ -95,8 +95,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -166,6 +173,7 @@
     const fileCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     const filePath = ref<string | null>(null);
     const contentType = ref<string>('application/unknown');
 
@@ -224,6 +232,14 @@
                 break;
             case 3:
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-t-thin';
+                }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
                     border += 'border-t-thin';
                 }
                 break;
@@ -239,6 +255,7 @@
         filePath.value = null;
         contentType.value = 'application/unknown';
         semanticId.value = null;
+        qualifiers.value = null;
         openPanels.value = [0, 1];
     }
 
@@ -264,6 +281,7 @@
             filePath.value = fileObject.value.value ?? null;
             contentType.value = fileObject.value.contentType ?? 'application/unknown';
             semanticId.value = fileObject.value.semanticId ?? null;
+            qualifiers.value = fileObject.value.qualifiers ?? null;
         }
     }
 
@@ -312,6 +330,7 @@
         }
 
         fileObject.value.category = fileCategory.value;
+        fileObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(fileObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/ListForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/ListForm.vue
@@ -114,8 +114,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -180,6 +187,7 @@
     const typeValueListElement = ref<aasTypes.AasSubmodelElements | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
 
     const errors = ref<Map<string, string>>(new Map());
 
@@ -238,6 +246,14 @@
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
                     border += ' border-t-thin';
                 }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-t-thin';
+                }
                 break;
         }
         return border;
@@ -263,6 +279,7 @@
         typeValueListElement.value = null;
         valueTypeListElement.value = aasTypes.DataTypeDefXsd.String;
         semanticId.value = null;
+        qualifiers.value = null;
         openPanels.value = [0, 1];
     }
 
@@ -289,6 +306,7 @@
             typeValueListElement.value = smlObject.value.typeValueListElement ?? null;
             valueTypeListElement.value = smlObject.value.valueTypeListElement ?? aasTypes.DataTypeDefXsd.String;
             semanticId.value = smlObject.value.semanticId ?? null;
+            qualifiers.value = smlObject.value.qualifiers ?? null;
         }
     }
 
@@ -332,6 +350,8 @@
         if (valueTypeListElement.value !== null) {
             smlObject.value.valueTypeListElement = valueTypeListElement.value;
         }
+
+        smlObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(smlObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/MLPForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/MLPForm.vue
@@ -91,8 +91,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -153,6 +160,7 @@
     const mlpCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     const mlpValue = ref<Array<aasTypes.LangStringTextType> | null>(null);
 
     const errors = ref<Map<string, string>>(new Map());
@@ -210,6 +218,14 @@
                 break;
             case 3:
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-t-thin';
+                }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
                     border += 'border-t-thin';
                 }
                 break;
@@ -262,6 +278,8 @@
         if (mlpValue.value !== null) {
             mlpObject.value.value = mlpValue.value;
         }
+
+        mlpObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(mlpObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {
@@ -359,6 +377,7 @@
         mlpCategory.value = null;
         mlpValue.value = null;
         semanticId.value = null;
+        qualifiers.value = null;
         openPanels.value = [0, 1];
     }
 
@@ -382,6 +401,7 @@
             mlpCategory.value = mlpObject.value.category ?? null;
             mlpValue.value = mlpObject.value.value ?? null;
             semanticId.value = mlpObject.value.semanticId ?? null;
+            qualifiers.value = mlpObject.value.qualifiers ?? null;
         }
     }
 </script>

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/PropertyForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/PropertyForm.vue
@@ -117,8 +117,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -185,6 +192,7 @@
     const propertyCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     const propertyValue = ref<string>('');
     const propertyValueErrorMessage = ref<string | null>(null);
     const valueType = ref<aasTypes.DataTypeDefXsd>(aasTypes.DataTypeDefXsd.String);
@@ -246,6 +254,14 @@
                 break;
             case 3:
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-t-thin';
+                }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
                     border += 'border-t-thin';
                 }
                 break;
@@ -317,6 +333,7 @@
         }
 
         propertyObject.value.category = propertyCategory.value;
+        propertyObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(propertyObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {
@@ -429,6 +446,7 @@
         propertyValueErrorMessage.value = null;
         valueType.value = aasTypes.DataTypeDefXsd.String;
         semanticId.value = null;
+        qualifiers.value = null;
         openPanels.value = [0, 1];
     }
 
@@ -454,6 +472,7 @@
             propertyValue.value = propertyObject.value.value ?? '';
             valueType.value = propertyObject.value.valueType ?? aasTypes.DataTypeDefXsd.String;
             semanticId.value = propertyObject.value.semanticId ?? null;
+            qualifiers.value = propertyObject.value.qualifiers ?? null;
         }
     }
 </script>

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/RangeForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/RangeForm.vue
@@ -107,8 +107,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -175,6 +182,7 @@
     const rangeCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     const minValue = ref<string | null>(null);
     const maxValue = ref<string | null>(null);
     const valueType = ref<aasTypes.DataTypeDefXsd>(aasTypes.DataTypeDefXsd.String);
@@ -234,6 +242,14 @@
                 break;
             case 3:
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-t-thin';
+                }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
                     border += 'border-t-thin';
                 }
                 break;
@@ -285,6 +301,7 @@
         }
 
         rangeObject.value.category = rangeCategory.value;
+        rangeObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(rangeObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {
@@ -384,6 +401,7 @@
         maxValue.value = null;
         valueType.value = aasTypes.DataTypeDefXsd.String;
         semanticId.value = null;
+        qualifiers.value = null;
         openPanels.value = [0, 1];
     }
 
@@ -410,6 +428,7 @@
             maxValue.value = rangeObject.value.max ?? null;
             valueType.value = rangeObject.value.valueType ?? aasTypes.DataTypeDefXsd.String;
             semanticId.value = rangeObject.value.semanticId ?? null;
+            qualifiers.value = rangeObject.value.qualifiers ?? null;
         }
     }
 </script>

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/ReferenceElementForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/ReferenceElementForm.vue
@@ -98,8 +98,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -159,6 +166,7 @@
     const referenceElementCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     const referenceElementValue = ref<aasTypes.Reference | null>(null);
 
     const errors = ref<Map<string, string>>(new Map());
@@ -218,6 +226,14 @@
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
                     border += ' border-t-thin';
                 }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-t-thin';
+                }
                 break;
         }
         return border;
@@ -267,6 +283,7 @@
         }
 
         referenceElementObject.value.category = referenceElementCategory.value;
+        referenceElementObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(referenceElementObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {
@@ -368,6 +385,7 @@
         description.value = null;
         referenceElementCategory.value = null;
         semanticId.value = null;
+        qualifiers.value = null;
         referenceElementValue.value = null;
         openPanels.value = [0, 1];
     }
@@ -391,6 +409,7 @@
             description.value = referenceElementObject.value.description ?? null;
             referenceElementCategory.value = referenceElementObject.value.category ?? null;
             semanticId.value = referenceElementObject.value.semanticId ?? null;
+            qualifiers.value = referenceElementObject.value.qualifiers ?? null;
             referenceElementValue.value = referenceElementObject.value.value ?? null;
         }
     }

--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/RelationshipElementForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/RelationshipElementForm.vue
@@ -103,8 +103,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -164,6 +171,7 @@
     const relationshipElementCategory = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
     const firstReference = ref<aasTypes.Reference | null>(null);
     const secondReference = ref<aasTypes.Reference | null>(null);
 
@@ -224,6 +232,14 @@
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
                     border += ' border-t-thin';
                 }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-t-thin';
+                }
                 break;
         }
         return border;
@@ -274,6 +290,7 @@
         }
 
         relationshipElementObject.value.category = relationshipElementCategory.value;
+        relationshipElementObject.value.qualifiers = qualifiers.value;
 
         const verificationResult = verifyForEditor(relationshipElementObject.value, { maxErrors: 10 });
         if (!verificationResult.isValid) {
@@ -375,6 +392,7 @@
         description.value = null;
         relationshipElementCategory.value = null;
         semanticId.value = null;
+        qualifiers.value = null;
         firstReference.value = null;
         secondReference.value = null;
         openPanels.value = [0, 1];
@@ -399,6 +417,7 @@
             description.value = relationshipElementObject.value.description ?? null;
             relationshipElementCategory.value = relationshipElementObject.value.category ?? null;
             semanticId.value = relationshipElementObject.value.semanticId ?? null;
+            qualifiers.value = relationshipElementObject.value.qualifiers ?? null;
             firstReference.value = relationshipElementObject.value.first ?? null;
             secondReference.value = relationshipElementObject.value.second ?? null;
         }

--- a/aas-web-ui/src/components/EditorComponents/SubmodelForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelForm.vue
@@ -130,8 +130,15 @@
                             </v-row>
                         </v-expansion-panel-text>
                     </v-expansion-panel>
+                    <!-- Qualifiers -->
+                    <v-expansion-panel class="border-s-thin border-e-thin" :class="bordersToShow(3)">
+                        <v-expansion-panel-title>Qualifiers</v-expansion-panel-title>
+                        <v-expansion-panel-text>
+                            <QualifierInput v-model="qualifiers" />
+                        </v-expansion-panel-text>
+                    </v-expansion-panel>
                     <!-- Data Specification -->
-                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(3)">
+                    <v-expansion-panel class="border-b-thin border-s-thin border-e-thin" :class="bordersToShow(4)">
                         <v-expansion-panel-title>Data Specification</v-expansion-panel-title>
                         <v-expansion-panel-text>
                             <span class="text-subtitleText text-subtitle-2">Coming soon!</span>
@@ -209,6 +216,7 @@
     const templateId = ref<string | null>(null);
 
     const semanticId = ref<aasTypes.Reference | null>(null);
+    const qualifiers = ref<Array<aasTypes.Qualifier> | null>(null);
 
     // Computed Properties
     const selectedNode = computed(() => aasStore.getSelectedNode); // Get the selected AAS from Store
@@ -240,6 +248,14 @@
                 break;
             case 3:
                 if (openPanels.value.includes(2) || openPanels.value.includes(3)) {
+                    border += ' border-t-thin';
+                }
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
+                    border += ' border-b-thin';
+                }
+                break;
+            case 4:
+                if (openPanels.value.includes(3) || openPanels.value.includes(4)) {
                     border = 'border-t-thin';
                 }
                 break;
@@ -293,6 +309,7 @@
                 templateId.value = submodelObject.value.administration.templateId ?? null;
             }
             semanticId.value = submodelObject.value.semanticId ?? null;
+            qualifiers.value = submodelObject.value.qualifiers ?? null;
         }
     }
 
@@ -365,6 +382,8 @@
         if (semanticId.value !== null) {
             submodelObject.value.semanticId = semanticId.value;
         }
+
+        submodelObject.value.qualifiers = qualifiers.value;
 
         // extensions are out of scope
         // SupplementalSemanticIds are out of scope
@@ -463,7 +482,8 @@
         creator.value = null;
         templateId.value = null;
         semanticId.value = null;
+        qualifiers.value = null;
         // Reset state of expansion panels
-        openPanels.value = [0, 3];
+        openPanels.value = [0, 4];
     }
 </script>


### PR DESCRIPTION
This pull request adds support for editing qualifiers in several submodel element forms within the AAS web UI. The main changes introduce a new `QualifierInput` component, integrate it into the forms for `AnnotatedRelationshipElement`, `Blob`, `Collection`, and `Entity`, and update the `SelectInput` component to handle qualifier kinds. The implementation ensures qualifiers are properly managed in form state and verification logic.

**New Qualifier Editing Functionality:**

* Added the new `QualifierInput.vue` component for editing qualifiers, including UI for adding/removing qualifiers and editing their fields, semantic IDs, and value IDs.
* Integrated `QualifierInput` into the forms for `AnnotatedRelationshipElement`, `Blob`, `Collection`, and `Entity`, allowing users to edit qualifiers for these elements. [[1]](diffhunk://#diff-6d7e6db6781a67d020017cacc5301ae851788cee74923e4219a40166f5f7658dR110-R118) [[2]](diffhunk://#diff-535fd2d823d62c6498694e14d6fc4ecbc61acb81c38a836eb8a2742e0a1940e0R97-R105) [[3]](diffhunk://#diff-d89f062a9b1555621407812e9e890a836af5c92cc2d38ff7e6aedfa2d988c704R79-R87) [[4]](diffhunk://#diff-a30a648bf1c8b94025c1d939de649ca0950bb553020f28cc68c0dd3677574bdfR98-R106)

**Form State and Logic Updates:**

* Updated form state to include qualifiers and ensured that qualifiers are properly reset, loaded, and saved in each form. [[1]](diffhunk://#diff-6d7e6db6781a67d020017cacc5301ae851788cee74923e4219a40166f5f7658dR178) [[2]](diffhunk://#diff-6d7e6db6781a67d020017cacc5301ae851788cee74923e4219a40166f5f7658dR398) [[3]](diffhunk://#diff-6d7e6db6781a67d020017cacc5301ae851788cee74923e4219a40166f5f7658dR425) [[4]](diffhunk://#diff-6d7e6db6781a67d020017cacc5301ae851788cee74923e4219a40166f5f7658dR297) [[5]](diffhunk://#diff-535fd2d823d62c6498694e14d6fc4ecbc61acb81c38a836eb8a2742e0a1940e0R176) [[6]](diffhunk://#diff-535fd2d823d62c6498694e14d6fc4ecbc61acb81c38a836eb8a2742e0a1940e0R256) [[7]](diffhunk://#diff-535fd2d823d62c6498694e14d6fc4ecbc61acb81c38a836eb8a2742e0a1940e0R282) [[8]](diffhunk://#diff-535fd2d823d62c6498694e14d6fc4ecbc61acb81c38a836eb8a2742e0a1940e0R338) [[9]](diffhunk://#diff-d89f062a9b1555621407812e9e890a836af5c92cc2d38ff7e6aedfa2d988c704R148) [[10]](diffhunk://#diff-d89f062a9b1555621407812e9e890a836af5c92cc2d38ff7e6aedfa2d988c704R254) [[11]](diffhunk://#diff-d89f062a9b1555621407812e9e890a836af5c92cc2d38ff7e6aedfa2d988c704R351) [[12]](diffhunk://#diff-d89f062a9b1555621407812e9e890a836af5c92cc2d38ff7e6aedfa2d988c704R374) [[13]](diffhunk://#diff-a30a648bf1c8b94025c1d939de649ca0950bb553020f28cc68c0dd3677574bdfR166)

**UI and Border Logic Adjustments:**

* Modified the expansion panel border logic to accommodate the new Qualifiers panel in all affected forms. [[1]](diffhunk://#diff-6d7e6db6781a67d020017cacc5301ae851788cee74923e4219a40166f5f7658dR239-R246) [[2]](diffhunk://#diff-535fd2d823d62c6498694e14d6fc4ecbc61acb81c38a836eb8a2742e0a1940e0R235-R242) [[3]](diffhunk://#diff-d89f062a9b1555621407812e9e890a836af5c92cc2d38ff7e6aedfa2d988c704R200-R207)

**SelectInput Component Enhancement:**

* Extended `SelectInput.vue` to support the new `qualifierKind` type, allowing users to select qualifier kinds from a dropdown. [[1]](diffhunk://#diff-f13e985725d9aff2eb2cccdaf0012ee05d7ae4e6b9de74d1d03cd0e4b45e16d4R24) [[2]](diffhunk://#diff-f13e985725d9aff2eb2cccdaf0012ee05d7ae4e6b9de74d1d03cd0e4b45e16d4R100-R105)