### PR TITLE
Resolves pnpm problems

### DIFF
--- a/aas-web-ui/pnpm-workspace.yaml
+++ b/aas-web-ui/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  '@parcel/watcher': true
+  'vue-demi': true


### PR DESCRIPTION
This pull request introduces a small configuration update to the `pnpm-workspace.yaml` file, allowing builds for two specific packages.

- Configuration:
  * Enabled builds for `@parcel/watcher` and `vue-demi` in the `allowBuilds` section of `pnpm-workspace.yaml`.