### PR TITLE
Extracts status checks in AAS List

### DIFF
--- a/aas-web-ui/src/components/AppNavigation/AASList.vue
+++ b/aas-web-ui/src/components/AppNavigation/AASList.vue
@@ -345,6 +345,7 @@
   import { useAASHandling } from '@/composables/AAS/AASHandling'
   import { appendOrMergeSortedAasById, compareAasById } from '@/composables/AAS/AASListAccumulation'
   import { useAASListPagination } from '@/composables/AAS/AASListPagination'
+  import { useAASListStatusChecks } from '@/composables/AAS/AASListStatusChecks'
   import { useReferableUtils } from '@/composables/AAS/ReferableUtils'
   import { useClipboardUtil } from '@/composables/ClipboardUtil'
   import { useAASStore } from '@/store/AASDataStore'
@@ -404,7 +405,6 @@
   const newShell = ref(false) // Variable to store if a new Shell should be created
   const aasToEdit = ref<any | undefined>(undefined) // Variable to store the AAS to be edited
   const statusCheckInterval = ref<number | undefined>(undefined)
-  const statusCheckInProgress = ref(false)
   const copyIcon = ref<string>('mdi-clipboard-file-outline')
   const instanceDialog = ref(false) // Variable to store if the Instance Creation Dialog should be shown
   const aasToInstantiate = ref({}) // Variable to store the AAS to be instantiated
@@ -446,6 +446,16 @@
         applyCurrentFilter()
       }
     },
+  })
+
+  const { updateStatus } = useAASListStatusChecks({
+    aasList,
+    getVirtualScrollContainer,
+    itemHeight,
+    viewportBufferRows: statusCheckViewportBufferRows,
+    fallbackLimit: statusCheckFallbackLimit,
+    concurrency: statusCheckConcurrency,
+    aasIsAvailableById,
   })
 
   // Computed Properties
@@ -527,11 +537,11 @@
     statusCheckValue => {
       window.clearInterval(statusCheckInterval.value) // clear old interval
       if (statusCheckValue.state === true) {
-        void updateStatus()
+        void updateStatus(statusCheckValue.state)
 
         // create new interval
         statusCheckInterval.value = window.setInterval(() => {
-          void updateStatus()
+          void updateStatus(statusCheck.value.state)
         }, statusCheck.value.interval)
       } else {
         for (const aasDescriptor of allLoadedAas.value) {
@@ -575,7 +585,7 @@
 
       // create new interval
       statusCheckInterval.value = window.setInterval(() => {
-        void updateStatus()
+        void updateStatus(statusCheck.value.state)
       }, statusCheck.value.interval)
     }
 
@@ -652,37 +662,6 @@
     })
   }
 
-  function getStatusCheckTargets (): Array<any> {
-    if (!Array.isArray(aasList.value) || aasList.value.length === 0) {
-      return []
-    }
-
-    const container = getVirtualScrollContainer()
-    let candidates: Array<any>
-
-    if (container) {
-      const visibleRows = Math.max(1, Math.ceil(container.clientHeight / itemHeight))
-      const firstVisibleIndex = Math.max(0, Math.floor(container.scrollTop / itemHeight) - statusCheckViewportBufferRows)
-      const endIndex = Math.min(
-        aasList.value.length,
-        firstVisibleIndex + visibleRows + statusCheckViewportBufferRows * 2,
-      )
-      candidates = aasList.value.slice(firstVisibleIndex, endIndex)
-    } else {
-      candidates = aasList.value.slice(0, statusCheckFallbackLimit)
-    }
-
-    const seenIds = new Set<string>()
-    return candidates.filter(item => {
-      const id = item?.id
-      if (!id || seenIds.has(id)) {
-        return false
-      }
-      seenIds.add(id)
-      return true
-    })
-  }
-
   function resetAASListState (enablePagination = true): void {
     aasList.value = []
     allLoadedAas.value = []
@@ -695,59 +674,6 @@
   async function initialize (): Promise<void> {
     resetAASListState(true)
     await initializePagination(scrollToSelectedAAS)
-  }
-
-  /**
-   * Updates the status of each AAS descriptor in the descriptor list.
-   *
-   * This function checks the availability of the AAS in the repository
-   * and updates its status based on the result.
-   *
-   * @param {boolean} [init=false] Indicates whether to initialize descriptor
-   * status. If true, sets status to an empty string; otherwise sets it based
-   * on availability checks.
-   */
-  async function updateStatus (init = false): Promise<void> {
-    if (statusCheckInProgress.value) {
-      return
-    }
-
-    const statusTargets = getStatusCheckTargets()
-    if (statusTargets.length === 0) {
-      return
-    }
-
-    statusCheckInProgress.value = true
-
-    try {
-      const queue = [...statusTargets]
-      const workerCount = Math.min(statusCheckConcurrency, queue.length)
-
-      // Limit concurrent availability requests to keep UI responsive and avoid request bursts.
-      const workers = Array.from({ length: workerCount }, async () => {
-        while (queue.length > 0) {
-          const aasOrAasDescriptor = queue.shift()
-
-          if (!aasOrAasDescriptor || Object.keys(aasOrAasDescriptor).length === 0) {
-            continue
-          }
-
-          const aasIsAvailable = await aasIsAvailableById(aasOrAasDescriptor.id)
-
-          if (aasIsAvailable) {
-            aasOrAasDescriptor.status
-              = statusCheck.value.state === true ? 'online' : (init ? '' : 'check disabled')
-          } else {
-            aasOrAasDescriptor.status
-              = statusCheck.value.state === true ? 'offline' : (init ? '' : 'check disabled')
-          }
-        }
-      })
-
-      await Promise.all(workers)
-    } finally {
-      statusCheckInProgress.value = false
-    }
   }
 
   function filterAasList (value: string | null): void {

--- a/aas-web-ui/src/composables/AAS/AASListStatusChecks.ts
+++ b/aas-web-ui/src/composables/AAS/AASListStatusChecks.ts
@@ -1,0 +1,101 @@
+import type { Ref } from 'vue'
+import { ref } from 'vue'
+
+export interface AasStatusCheckItem {
+  id?: string
+  status?: string
+}
+
+export interface UseAASListStatusChecksOptions<TItem extends AasStatusCheckItem = AasStatusCheckItem> {
+  aasList: Ref<Array<TItem>>
+  getVirtualScrollContainer: () => HTMLElement | null
+  itemHeight: number
+  viewportBufferRows: number
+  fallbackLimit: number
+  concurrency: number
+  aasIsAvailableById: (aasId: string) => Promise<boolean>
+}
+
+export function useAASListStatusChecks<TItem extends AasStatusCheckItem = AasStatusCheckItem> (
+  options: UseAASListStatusChecksOptions<TItem>,
+) {
+  const statusCheckInProgress = ref(false)
+
+  function getStatusCheckTargets (): Array<TItem> {
+    if (!Array.isArray(options.aasList.value) || options.aasList.value.length === 0) {
+      return []
+    }
+
+    const container = options.getVirtualScrollContainer()
+    let candidates: Array<TItem>
+
+    if (container) {
+      const visibleRows = Math.max(1, Math.ceil(container.clientHeight / options.itemHeight))
+      const firstVisibleIndex = Math.max(0, Math.floor(container.scrollTop / options.itemHeight) - options.viewportBufferRows)
+      const endIndex = Math.min(
+        options.aasList.value.length,
+        firstVisibleIndex + visibleRows + options.viewportBufferRows * 2,
+      )
+      candidates = options.aasList.value.slice(firstVisibleIndex, endIndex)
+    } else {
+      candidates = options.aasList.value.slice(0, options.fallbackLimit)
+    }
+
+    const seenIds = new Set<string>()
+    return candidates.filter(item => {
+      const id = item?.id
+      if (!id || seenIds.has(id)) {
+        return false
+      }
+      seenIds.add(id)
+      return true
+    })
+  }
+
+  async function updateStatus (statusCheckEnabled: boolean, init = false): Promise<void> {
+    if (statusCheckInProgress.value) {
+      return
+    }
+
+    const statusTargets = getStatusCheckTargets()
+    if (statusTargets.length === 0) {
+      return
+    }
+
+    statusCheckInProgress.value = true
+
+    try {
+      const queue = [...statusTargets]
+      const workerCount = Math.min(options.concurrency, queue.length)
+
+      const workers = Array.from({ length: workerCount }, async () => {
+        while (queue.length > 0) {
+          const aasOrAasDescriptor = queue.shift()
+
+          if (!aasOrAasDescriptor || !aasOrAasDescriptor.id) {
+            continue
+          }
+
+          const aasIsAvailable = await options.aasIsAvailableById(aasOrAasDescriptor.id)
+
+          if (aasIsAvailable) {
+            aasOrAasDescriptor.status
+              = statusCheckEnabled ? 'online' : (init ? '' : 'check disabled')
+          } else {
+            aasOrAasDescriptor.status
+              = statusCheckEnabled ? 'offline' : (init ? '' : 'check disabled')
+          }
+        }
+      })
+
+      await Promise.all(workers)
+    } finally {
+      statusCheckInProgress.value = false
+    }
+  }
+
+  return {
+    updateStatus,
+    getStatusCheckTargets,
+  }
+}

--- a/aas-web-ui/src/composables/AAS/AASListStatusChecks.ts
+++ b/aas-web-ui/src/composables/AAS/AASListStatusChecks.ts
@@ -62,11 +62,21 @@ export function useAASListStatusChecks<TItem extends AasStatusCheckItem = AasSta
       return
     }
 
+    if (!statusCheckEnabled) {
+      for (const aasOrAasDescriptor of statusTargets) {
+        aasOrAasDescriptor.status = init ? '' : 'check disabled'
+      }
+      return
+    }
+
     statusCheckInProgress.value = true
 
     try {
       const queue = [...statusTargets]
-      const workerCount = Math.min(options.concurrency, queue.length)
+      const normalizedConcurrency = Number.isFinite(options.concurrency)
+        ? Math.max(1, Math.floor(options.concurrency))
+        : 1
+      const workerCount = Math.min(normalizedConcurrency, queue.length)
 
       const workers = Array.from({ length: workerCount }, async () => {
         while (queue.length > 0) {

--- a/aas-web-ui/tests/composables/AAS/AASListStatusChecks.test.ts
+++ b/aas-web-ui/tests/composables/AAS/AASListStatusChecks.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ref } from 'vue'
+
+import { useAASListStatusChecks } from '@/composables/AAS/AASListStatusChecks'
+
+describe('AASListStatusChecks.ts', () => {
+  it('uses fallback targets, de-duplicates by id, and updates online/offline status', async () => {
+    const aasList = ref([
+      { id: 'aas-1' },
+      { id: 'aas-1' },
+      { id: 'aas-2' },
+      { id: 'aas-3' },
+    ])
+
+    const aasIsAvailableById = vi.fn(async (id: string) => id === 'aas-1')
+
+    const { updateStatus } = useAASListStatusChecks({
+      aasList,
+      getVirtualScrollContainer: () => null,
+      itemHeight: 56,
+      viewportBufferRows: 1,
+      fallbackLimit: 3,
+      concurrency: 2,
+      aasIsAvailableById,
+    })
+
+    await updateStatus(true)
+
+    expect(aasIsAvailableById).toHaveBeenCalledTimes(2)
+    expect(aasIsAvailableById).toHaveBeenCalledWith('aas-1')
+    expect(aasIsAvailableById).toHaveBeenCalledWith('aas-2')
+    expect(aasList.value[0].status).toBe('online')
+    expect(aasList.value[2].status).toBe('offline')
+    expect(aasList.value[3].status).toBeUndefined()
+  })
+
+  it('limits checks to current visible virtual-scroll slice', async () => {
+    const aasList = ref([
+      { id: 'aas-1' },
+      { id: 'aas-2' },
+      { id: 'aas-3' },
+      { id: 'aas-4' },
+      { id: 'aas-5' },
+      { id: 'aas-6' },
+    ])
+
+    const container = document.createElement('div')
+    Object.defineProperty(container, 'clientHeight', {
+      value: 112,
+      configurable: true,
+    })
+    Object.defineProperty(container, 'scrollTop', {
+      value: 56,
+      configurable: true,
+      writable: true,
+    })
+
+    const aasIsAvailableById = vi.fn(async () => true)
+
+    const { updateStatus } = useAASListStatusChecks({
+      aasList,
+      getVirtualScrollContainer: () => container,
+      itemHeight: 56,
+      viewportBufferRows: 1,
+      fallbackLimit: 6,
+      concurrency: 2,
+      aasIsAvailableById,
+    })
+
+    await updateStatus(true)
+
+    expect(aasIsAvailableById).toHaveBeenCalledTimes(4)
+    expect(aasIsAvailableById).toHaveBeenNthCalledWith(1, 'aas-1')
+    expect(aasIsAvailableById).toHaveBeenNthCalledWith(2, 'aas-2')
+    expect(aasIsAvailableById).toHaveBeenNthCalledWith(3, 'aas-3')
+    expect(aasIsAvailableById).toHaveBeenNthCalledWith(4, 'aas-4')
+  })
+
+  it('prevents overlapping update runs while one is in progress', async () => {
+    const aasList = ref([{ id: 'aas-1' }])
+    let resolveAvailability!: (value: boolean) => void
+    const aasIsAvailableById = vi.fn(() => new Promise<boolean>(resolve => {
+      resolveAvailability = resolve
+    }))
+
+    const { updateStatus } = useAASListStatusChecks({
+      aasList,
+      getVirtualScrollContainer: () => null,
+      itemHeight: 56,
+      viewportBufferRows: 1,
+      fallbackLimit: 1,
+      concurrency: 1,
+      aasIsAvailableById,
+    })
+
+    const firstRun = updateStatus(true)
+    const secondRun = updateStatus(true)
+
+    expect(aasIsAvailableById).toHaveBeenCalledTimes(1)
+
+    resolveAvailability(true)
+    await firstRun
+    await secondRun
+
+    expect(aasList.value[0].status).toBe('online')
+  })
+
+  it('writes disabled status when checks are disabled', async () => {
+    const aasList = ref([{ id: 'aas-1' }])
+    const aasIsAvailableById = vi.fn(async () => true)
+
+    const { updateStatus } = useAASListStatusChecks({
+      aasList,
+      getVirtualScrollContainer: () => null,
+      itemHeight: 56,
+      viewportBufferRows: 1,
+      fallbackLimit: 1,
+      concurrency: 1,
+      aasIsAvailableById,
+    })
+
+    await updateStatus(false)
+
+    expect(aasList.value[0].status).toBe('check disabled')
+  })
+})

--- a/aas-web-ui/tests/composables/AAS/AASListStatusChecks.test.ts
+++ b/aas-web-ui/tests/composables/AAS/AASListStatusChecks.test.ts
@@ -3,9 +3,14 @@ import { ref } from 'vue'
 
 import { useAASListStatusChecks } from '@/composables/AAS/AASListStatusChecks'
 
+type TestAasStatusItem = {
+  id: string
+  status?: string
+}
+
 describe('AASListStatusChecks.ts', () => {
   it('uses fallback targets, de-duplicates by id, and updates online/offline status', async () => {
-    const aasList = ref([
+    const aasList = ref<Array<TestAasStatusItem>>([
       { id: 'aas-1' },
       { id: 'aas-1' },
       { id: 'aas-2' },
@@ -35,7 +40,7 @@ describe('AASListStatusChecks.ts', () => {
   })
 
   it('limits checks to current visible virtual-scroll slice', async () => {
-    const aasList = ref([
+    const aasList = ref<Array<TestAasStatusItem>>([
       { id: 'aas-1' },
       { id: 'aas-2' },
       { id: 'aas-3' },
@@ -70,14 +75,14 @@ describe('AASListStatusChecks.ts', () => {
     await updateStatus(true)
 
     expect(aasIsAvailableById).toHaveBeenCalledTimes(4)
-    expect(aasIsAvailableById).toHaveBeenNthCalledWith(1, 'aas-1')
-    expect(aasIsAvailableById).toHaveBeenNthCalledWith(2, 'aas-2')
-    expect(aasIsAvailableById).toHaveBeenNthCalledWith(3, 'aas-3')
-    expect(aasIsAvailableById).toHaveBeenNthCalledWith(4, 'aas-4')
+    expect(aasIsAvailableById).toHaveBeenCalledWith('aas-1')
+    expect(aasIsAvailableById).toHaveBeenCalledWith('aas-2')
+    expect(aasIsAvailableById).toHaveBeenCalledWith('aas-3')
+    expect(aasIsAvailableById).toHaveBeenCalledWith('aas-4')
   })
 
   it('prevents overlapping update runs while one is in progress', async () => {
-    const aasList = ref([{ id: 'aas-1' }])
+    const aasList = ref<Array<TestAasStatusItem>>([{ id: 'aas-1' }])
     let resolveAvailability!: (value: boolean) => void
     const aasIsAvailableById = vi.fn(() => new Promise<boolean>(resolve => {
       resolveAvailability = resolve
@@ -105,8 +110,28 @@ describe('AASListStatusChecks.ts', () => {
     expect(aasList.value[0].status).toBe('online')
   })
 
+  it('processes targets when configured concurrency is 0', async () => {
+    const aasList = ref<Array<TestAasStatusItem>>([{ id: 'aas-1' }])
+    const aasIsAvailableById = vi.fn(async () => true)
+
+    const { updateStatus } = useAASListStatusChecks({
+      aasList,
+      getVirtualScrollContainer: () => null,
+      itemHeight: 56,
+      viewportBufferRows: 1,
+      fallbackLimit: 1,
+      concurrency: 0,
+      aasIsAvailableById,
+    })
+
+    await updateStatus(true)
+
+    expect(aasIsAvailableById).toHaveBeenCalledTimes(1)
+    expect(aasList.value[0].status).toBe('online')
+  })
+
   it('writes disabled status when checks are disabled', async () => {
-    const aasList = ref([{ id: 'aas-1' }])
+    const aasList = ref<Array<TestAasStatusItem>>([{ id: 'aas-1' }])
     const aasIsAvailableById = vi.fn(async () => true)
 
     const { updateStatus } = useAASListStatusChecks({
@@ -121,6 +146,7 @@ describe('AASListStatusChecks.ts', () => {
 
     await updateStatus(false)
 
+    expect(aasIsAvailableById).not.toHaveBeenCalled()
     expect(aasList.value[0].status).toBe('check disabled')
   })
 })


### PR DESCRIPTION
This pull request refactors the status checking logic for AAS descriptors in the UI by extracting it into a new composable, improving modularity, testability, and maintainability. The main logic for determining which AAS items to check (including virtual scroll awareness, deduplication, and concurrency) is now encapsulated in `useAASListStatusChecks`, and comprehensive unit tests have been added to ensure correct behavior.

Key changes include:

**Refactoring and Code Organization:**
* Extracted the status checking logic from `AASList.vue` into a new composable `useAASListStatusChecks`, which handles target selection, deduplication, and concurrent status updates for AAS items. This makes the code more modular and easier to maintain. [[1]](diffhunk://#diff-e1ddfebf3da2f7a7cb4619d9b2dd31a20f083463d33f4a56c29ff1bf8df23fd2R1-R101) [[2]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL655-L685) [[3]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL700-L752)

**Integration and Usage Updates:**
* Updated `AASList.vue` to use the new composable for status updates, simplifying the component and removing redundant code and state (such as `statusCheckInProgress` and the old `updateStatus`/`getStatusCheckTargets` functions). [[1]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaR348) [[2]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL407) [[3]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaR451-R460) [[4]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL530-R544) [[5]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL578-R588)

**Testing Improvements:**
* Added a new test suite `AASListStatusChecks.test.ts` to cover the main features of the composable, including deduplication, virtual scroll handling, concurrency, prevention of overlapping runs, and correct status assignment when checks are disabled.