### PR TITLE
Adds vitest testTimeout

### DIFF
--- a/aas-web-ui/pnpm-workspace.yaml
+++ b/aas-web-ui/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
 allowBuilds:
   '@parcel/watcher': true
   'vue-demi': true
+packages:
+    - '.'

--- a/aas-web-ui/src/components/AppNavigation/MainMenu.vue
+++ b/aas-web-ui/src/components/AppNavigation/MainMenu.vue
@@ -186,7 +186,6 @@
 
         <v-btn
           append-icon="custom:aasIcon"
-
           color="primary"
           href="https://basyx.org"
           target="_blank"

--- a/aas-web-ui/vitest.config.mts
+++ b/aas-web-ui/vitest.config.mts
@@ -15,6 +15,7 @@ export default defineConfig(env => {
   return mergeConfig(resolvedViteConfig, {
     test: {
       globals: true,
+      testTimeout: 30_000,
       environment: 'jsdom',
       server: {
         deps: {


### PR DESCRIPTION
This PR adds vitest testTimeout of 30 seonds

Note: One test seems to need a little bit longer that the default of 5 seconds (tested on different windows machines).

``` shell
...
✓ tests/composables/Client/AASRepositoryClient.test.ts (2 tests) 6616ms
     ✓ passes limit and cursor query params and parses next cursor  6613ms
...
```

This PR also fixes an error occuring for the run of the GitHub Workflow ".github/workflows/build-aas-web-ui.yml", Job "build":
<img width="274" height="106" alt="image" src="https://github.com/user-attachments/assets/991efda1-508f-41ce-be0c-9b89738200d7" />
