### PR TITLE
Adds mosquitto volume mount directories to gitignore

### DIFF
--- a/examples/CombinedExample/Infrastructure1/.gitignore
+++ b/examples/CombinedExample/Infrastructure1/.gitignore
@@ -1,1 +1,3 @@
 /influxdb
+/mosquitto/data
+/mosquitto/log

--- a/examples/TimeSeriesData/.gitignore
+++ b/examples/TimeSeriesData/.gitignore
@@ -1,1 +1,3 @@
 /influxdb
+/mosquitto/data
+/mosquitto/log


### PR DESCRIPTION
This pull request updates `.gitignore` files in two example projects to exclude additional directories related to Mosquitto. This helps prevent local Mosquitto data and log files from being accidentally committed to the repository.

.gitignore improvements:

* Added `/mosquitto/data` and `/mosquitto/log` to `.gitignore` in both `examples/CombinedExample/Infrastructure1` and `examples/TimeSeriesData` to ensure Mosquitto runtime files are ignored.