### PR TITLE
Adds .dockerignore

### DIFF
--- a/aas-web-ui/.dockerignore
+++ b/aas-web-ui/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist


### PR DESCRIPTION
## Description of Changes

This PR adds .dockerignore to prevent local node_modules and dist from being copied into Docker build

### Root cause:
The `COPY . .` instruction in the Dockerfile copied the local node_modules and dist directories into the container, overwriting the dependencies previously installed by pnpm install --frozen-lockfile. This resulted in missing or platform-incompatible packages at build time.