### PR TITLE
Fixes reactivity problem with BoM Submodel rendering

### DIFF
--- a/aas-web-ui/src/components/EditorComponents/SubmodelElements/EntityForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelElements/EntityForm.vue
@@ -164,13 +164,16 @@
   import { keyDown, keyUp } from '@/utils/EditorUtils'
   import { base64Decode } from '@/utils/EncodeDecodeUtils'
 
-  const props = defineProps<{
+  const props = withDefaults(defineProps<{
     modelValue: boolean
     newEntity: boolean
     parentElement: any
     path?: string
     entity?: any
-  }>()
+    selectCreatedEntity?: boolean
+  }>(), {
+    selectCreatedEntity: true,
+  })
 
   // Stores
   const navigationStore = useNavigationStore()
@@ -348,9 +351,11 @@
         const query = structuredClone(route.query)
         query.path = props.parentElement.path + '/submodel-elements/' + entityObject.value.idShort
 
-        router.push({
-          query: query,
-        })
+        if (props.selectCreatedEntity) {
+          router.push({
+            query: query,
+          })
+        }
       } else {
         // Extract the submodel ID and the idShortPath from the parentElement path
         const splitted = props.parentElement.path.split('/submodel-elements/')
@@ -365,9 +370,11 @@
           const query = structuredClone(route.query)
           query.path = createdPath
 
-          router.push({
-            query: query,
-          })
+          if (props.selectCreatedEntity) {
+            router.push({
+              query: query,
+            })
+          }
         }
       }
     } else {

--- a/aas-web-ui/src/components/Plugins/Submodels/HierarchicalStructures_v1_x.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/HierarchicalStructures_v1_x.vue
@@ -88,6 +88,7 @@
       :new-entity="newEntity"
       :parent-element="elementToAddSME"
       :path="submodelElementPath"
+      :select-created-entity="false"
       @update:model-value="onDialogClosed"
     />
     <!-- Dialog for deleting SM/SME -->

--- a/aas-web-ui/src/components/Plugins/Submodels/HierarchicalStructures_v1_x.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/HierarchicalStructures_v1_x.vue
@@ -232,7 +232,7 @@
   import { Background } from '@vue-flow/background'
   import { Controls } from '@vue-flow/controls'
   import { MarkerType, useVueFlow, VueFlow } from '@vue-flow/core'
-  import { computed, h, onMounted, ref, watch } from 'vue'
+  import { computed, h, nextTick, onMounted, ref, watch } from 'vue'
   import { useRoute, useRouter } from 'vue-router'
   import { useTheme } from 'vuetify'
   import { useReferableUtils } from '@/composables/AAS/ReferableUtils'
@@ -303,6 +303,7 @@
   const nodeMap = ref<Map<string, unknown>>(new Map())
   const hasSelfLoopEdges = ref(false)
   const entryNode = ref<Record<string, unknown> | undefined>(undefined)
+  let visualizationUpdateId = 0
 
   const entityDialog = ref(false)
   const newEntity = ref(false)
@@ -452,19 +453,26 @@
   })
 
   async function initializeVisualization (): Promise<void> {
+    const updateId = ++visualizationUpdateId
     isLoading.value = true
 
-    if (hasNoSubmodelData()) {
-      resetVisualization()
-      isLoading.value = false
-      return
+    try {
+      if (hasNoSubmodelData()) {
+        resetVisualization()
+        return
+      }
+
+      const nextBomData = await setData({ ...props.submodelElementData }, props.submodelElementData.path)
+      if (updateId !== visualizationUpdateId) return
+
+      bomData.value = nextBomData
+      archetype.value = getArchetype(bomData.value)
+      await buildFlowGraph(bomData.value, updateId)
+    } finally {
+      if (updateId === visualizationUpdateId) {
+        isLoading.value = false
+      }
     }
-
-    bomData.value = await setData({ ...props.submodelElementData }, props.submodelElementData.path)
-    archetype.value = getArchetype(bomData.value)
-    buildFlowGraph(bomData.value)
-
-    isLoading.value = false
   }
 
   function hasNoSubmodelData (): boolean {
@@ -473,11 +481,14 @@
 
   function resetVisualization (): void {
     bomData.value = {}
+    entryNode.value = undefined
+    nodeMap.value.clear()
+    hasSelfLoopEdges.value = false
     nodes.value = []
     edges.value = []
   }
 
-  function buildFlowGraph (bomData: Record<string, unknown>): void {
+  async function buildFlowGraph (bomData: Record<string, unknown>, updateId: number): Promise<void> {
     entryNode.value = findEntryNode(bomData)
 
     if (!canBuildGraph(entryNode.value)) {
@@ -495,7 +506,18 @@
     // Check if there are self-loop edges
     hasSelfLoopEdges.value = tempEdges.some(e => e.type === 'selfloop')
 
+    await publishFlowGraph(tempNodes, tempEdges, updateId)
+  }
+
+  async function publishFlowGraph (tempNodes: Node[], tempEdges: Edge[], updateId: number): Promise<void> {
+    // Vue Flow validates edges against its internal node lookup as soon as edges change.
+    // Publish nodes one tick earlier so first render has all edge endpoints available.
+    edges.value = []
     nodes.value = tempNodes
+
+    await nextTick()
+    if (updateId !== visualizationUpdateId) return
+
     edges.value = tempEdges
   }
 


### PR DESCRIPTION
This pull request introduces improvements to the entity creation flow and enhances the robustness and responsiveness of the hierarchical structure visualization in the UI. The main changes include making entity selection after creation configurable, preventing race conditions during visualization updates, and optimizing the rendering of flow graphs.

**Entity Creation Flow:**
* Made the selection of a newly created entity configurable via a new `selectCreatedEntity` prop in `EntityForm.vue`, defaulting to `true` for backward compatibility. This allows parent components to control whether the UI should automatically select the created entity. (`EntityForm.vue`, `HierarchicalStructures_v1_x.vue`) [[1]](diffhunk://#diff-a30a648bf1c8b94025c1d939de649ca0950bb553020f28cc68c0dd3677574bdfL167-R176) [[2]](diffhunk://#diff-344093fe2ce58901e1db1abb1038652698a884d1220278048b4c0a2ea341a6c8R91)
* Updated the logic in `EntityForm.vue` to only navigate to the newly created entity if `selectCreatedEntity` is true, improving flexibility for different usage scenarios. [[1]](diffhunk://#diff-a30a648bf1c8b94025c1d939de649ca0950bb553020f28cc68c0dd3677574bdfR354-R358) [[2]](diffhunk://#diff-a30a648bf1c8b94025c1d939de649ca0950bb553020f28cc68c0dd3677574bdfR373-R379)

**Visualization Robustness and Performance:**
* Introduced an `updateId` mechanism in `HierarchicalStructures_v1_x.vue` to prevent race conditions when multiple visualization updates are triggered in quick succession, ensuring only the latest update is applied. [[1]](diffhunk://#diff-344093fe2ce58901e1db1abb1038652698a884d1220278048b4c0a2ea341a6c8R307) [[2]](diffhunk://#diff-344093fe2ce58901e1db1abb1038652698a884d1220278048b4c0a2ea341a6c8R457-R492)
* Refactored the flow graph rendering logic to publish nodes before edges and use `nextTick` for proper synchronization with Vue's rendering cycle, preventing edge validation errors and ensuring graph consistency.
* Improved the `resetVisualization` function to clear all relevant state, ensuring a clean slate when re-initializing the visualization.

**Other Improvements:**
* Added `nextTick` to the imports in `HierarchicalStructures_v1_x.vue` for improved rendering flow.