### PR TITLE
Module visibility for specific routes

### DIFF
--- a/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
+++ b/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
@@ -282,13 +282,12 @@
 
 <script lang="ts" setup>
   import type { AutoSyncType, StatusCheckType } from '@/types/Application'
-  import type { RouteRecordRaw } from 'vue-router'
   import { computed, onMounted, ref, watch } from 'vue'
   import { useRoute } from 'vue-router'
   import { useTheme } from 'vuetify'
   import Snackbar from '@/components/AppNavigation/Snackbar.vue'
+  import { useModuleHandling } from '@/composables/ModuleHandling'
   import { useGlobalShortcuts } from '@/composables/Shortcuts/useGlobalShortcuts'
-  import { useAASStore } from '@/store/AASDataStore'
   import { useEnvStore } from '@/store/EnvironmentStore'
   import { useNavigationStore } from '@/store/NavigationStore'
 
@@ -298,7 +297,9 @@
   // Stores
   const navigationStore = useNavigationStore()
   const envStore = useEnvStore()
-  const aasStore = useAASStore()
+
+  // Composables
+  const { determineFilteredAndOrderedModuleRoutes, isActiveModuleRoute } = useModuleHandling()
 
   // Vuetify
   const theme = useTheme()
@@ -327,9 +328,6 @@
   const currentRoute = computed(() => route.name) // get the current route name
   const isMobile = computed(() => navigationStore.getIsMobile)
   const isDark = computed(() => theme.global.current.value.dark)
-  const selectedAas = computed(() => aasStore.getSelectedAAS) // get selected AAS from Store
-  const selectedNode = computed(() => aasStore.getSelectedNode) // get selected AAS from Store
-  const moduleRoutes = computed(() => navigationStore.getModuleRoutes) // get the module routes
   const endpointConfigAvailable = computed(() => envStore.getEndpointConfigAvailable)
   const menuToggleTitle = computed(() => {
     if (route.path.startsWith('/modules/')) {
@@ -343,41 +341,6 @@
 
     if (route.meta?.title) return route.meta.title.toString()
     return route.meta?.name?.toString() || ''
-  })
-
-  const filteredAndOrderedModuleRoutes = computed(() => {
-    const filteredModuleRoutes = moduleRoutes.value.filter((moduleRoute: RouteRecordRaw) => {
-      if (isMobile.value && !moduleRoute?.meta?.isMobileModule) return false
-      if (!isMobile.value && !moduleRoute?.meta?.isDesktopModule) return false
-      if (
-        moduleRoute?.meta?.isOnlyVisibleWithSelectedAas
-        && (!selectedAas.value || Object.keys(selectedAas.value).length === 0)
-      )
-        return false
-      if (
-        moduleRoute?.meta?.isOnlyVisibleWithSelectedNode
-        && (!selectedNode.value || Object.keys(selectedNode.value).length === 0)
-      )
-        return false
-      if (
-        moduleRoute?.meta?.routeModule
-        && Array.isArray(moduleRoute.meta.routeModule)
-        && moduleRoute.meta.routeModule.length > 0
-        && !moduleRoute.meta.routeModule.map(item => item.toLowerCase()).includes((route.name as string).toLowerCase())
-      )
-        return false
-      return moduleRoute?.meta?.isVisibleModule === true || isActiveModuleRoute(moduleRoute.path)
-    })
-
-    const filteredAndOrderedModuleRoutes = filteredModuleRoutes.toSorted(
-      (moduleRouteA: RouteRecordRaw, moduleRouteB: RouteRecordRaw) => {
-        const moduleNameA: string = moduleRouteA?.name?.toString() || ''
-        const moduleNameB: string = moduleRouteB?.name?.toString() || ''
-        return moduleNameA.localeCompare(moduleNameB)
-      },
-    )
-
-    return filteredAndOrderedModuleRoutes
   })
   const showAASList = computed(() => ['AASViewer', 'AASEditor', 'AASSubmodelViewer'].includes(route.name as string))
   const drawerState = computed(() => navigationStore.getDrawerState)
@@ -413,6 +376,8 @@
       'AASCommander',
     ].includes(route.name as string)
   })
+
+  const filteredAndOrderedModuleRoutes = determineFilteredAndOrderedModuleRoutes()
 
   watch(
     () => drawerState.value,
@@ -486,7 +451,4 @@
     }
   }
 
-  function isActiveModuleRoute (routePath: string): boolean {
-    return route.path === routePath || route.path.startsWith(`${routePath}/`)
-  }
 </script>

--- a/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
+++ b/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
@@ -359,8 +359,16 @@
         && (!selectedNode.value || Object.keys(selectedNode.value).length === 0)
       )
         return false
+      if (
+        moduleRoute?.meta?.routeModule
+        && Array.isArray(moduleRoute.meta.routeModule)
+        && moduleRoute.meta.routeModule.length > 0
+        && !moduleRoute.meta.routeModule.map(item => item.toLowerCase()).includes((route.name as string).toLowerCase())
+      )
+        return false
       return moduleRoute?.meta?.isVisibleModule === true || isActiveModuleRoute(moduleRoute.path)
     })
+
     const filteredAndOrderedModuleRoutes = filteredModuleRoutes.toSorted(
       (moduleRouteA: RouteRecordRaw, moduleRouteB: RouteRecordRaw) => {
         const moduleNameA: string = moduleRouteA?.name?.toString() || ''
@@ -368,6 +376,7 @@
         return moduleNameA.localeCompare(moduleNameB)
       },
     )
+
     return filteredAndOrderedModuleRoutes
   })
   const showAASList = computed(() => ['AASViewer', 'AASEditor', 'AASSubmodelViewer'].includes(route.name as string))

--- a/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
+++ b/aas-web-ui/src/components/AppNavigation/AppNavigation.vue
@@ -377,7 +377,7 @@
     ].includes(route.name as string)
   })
 
-  const filteredAndOrderedModuleRoutes = determineFilteredAndOrderedModuleRoutes()
+  const filteredAndOrderedModuleRoutes = computed(() => determineFilteredAndOrderedModuleRoutes())
 
   watch(
     () => drawerState.value,

--- a/aas-web-ui/src/components/AppNavigation/MainMenu.vue
+++ b/aas-web-ui/src/components/AppNavigation/MainMenu.vue
@@ -214,9 +214,9 @@
   import type { RouteRecordRaw } from 'vue-router'
   import { computed, onMounted, ref } from 'vue'
   import { useRoute } from 'vue-router'
+  import { useModuleHandling } from '@/composables/ModuleHandling'
   import { useAASStore } from '@/store/AASDataStore'
   import { useEnvStore } from '@/store/EnvironmentStore'
-  import { useNavigationStore } from '@/store/NavigationStore'
 
   // Extend the ComponentPublicInstance type to include scrollToIndex
   interface VirtualScrollInstance extends ComponentPublicInstance {
@@ -229,7 +229,9 @@
   // Stores
   const aasStore = useAASStore()
   const envStore = useEnvStore()
-  const navigationStore = useNavigationStore()
+
+  // Composables
+  const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
 
   // Emit
   const emit = defineEmits<{
@@ -241,48 +243,12 @@
   const currentTab: Ref<string> = ref('aas') // Current Tab Index
 
   // Computed Properties
-  const isMobile = computed(() => navigationStore.getIsMobile) // Check if the current Device is a Mobile Device
   const currentRoutePath = computed(() => route.path) // get the current route path
   const allowEditing = computed(() => envStore.getAllowEditing) // Check if the current environment allows showing the AAS resp. SM Editor
   const smViewerEditor = computed(() => envStore.getSmViewerEditor) // Check the current environment allows showing the SM Viewer/Editor
-  const moduleRoutes = computed(() => navigationStore.getModuleRoutes) // get the module routes
-  const selectedAas = computed(() => aasStore.getSelectedAAS) // get selected AAS from Store
   const selectedNode = computed(() => aasStore.getSelectedNode) // get selected AAS from Store
-  const filteredAndOrderedModuleRoutes = computed(() => {
-    const filteredModuleRoutes = moduleRoutes.value.filter((moduleRoute: RouteRecordRaw) => {
-      if (isMobile.value && !moduleRoute?.meta?.isMobileModule) return false
-      if (!isMobile.value && !moduleRoute?.meta?.isDesktopModule) return false
-      if (
-        moduleRoute?.meta?.isOnlyVisibleWithSelectedAas
-        && (!selectedAas.value || Object.keys(selectedAas.value).length === 0)
-      )
-        return false
-      if (
-        moduleRoute?.meta?.isOnlyVisibleWithSelectedNode
-        && (!selectedNode.value || Object.keys(selectedNode.value).length === 0)
-      )
-        return false
-      if (
-        moduleRoute?.meta?.routeModule
-        && Array.isArray(moduleRoute.meta.routeModule)
-        && moduleRoute.meta.routeModule.length > 0
-        && !moduleRoute.meta.routeModule.map(item => item.toLowerCase()).includes((route.name as string).toLowerCase())
-      )
-        return false
-      return moduleRoute?.meta?.isVisibleModule === true || isActiveRoutePath(moduleRoute.path)
-    })
 
-    const filteredAndOrderedModuleRoutes = filteredModuleRoutes.toSorted(
-      (moduleRouteA: RouteRecordRaw, moduleRouteB: RouteRecordRaw) => {
-        const moduleNameA: string = moduleRouteA?.name?.toString() || ''
-        const moduleNameB: string = moduleRouteB?.name?.toString() || ''
-
-        return moduleNameA.localeCompare(moduleNameB)
-      },
-    )
-
-    return filteredAndOrderedModuleRoutes
-  })
+  const filteredAndOrderedModuleRoutes = determineFilteredAndOrderedModuleRoutes()
 
   onMounted(async () => {
     scrollToSelectedModule()
@@ -300,7 +266,7 @@
   // Function to scroll to the active module
   function scrollToSelectedModule (): void {
     // Find the index of the selected item
-    const index = filteredAndOrderedModuleRoutes.value.findIndex((moduleRoute: RouteRecordRaw) =>
+    const index = filteredAndOrderedModuleRoutes.findIndex((moduleRoute: RouteRecordRaw) =>
       isActiveRoutePath(moduleRoute.path),
     )
 
@@ -327,4 +293,5 @@
       currentTab.value = 'modules'
     }
   }
+
 </script>

--- a/aas-web-ui/src/components/AppNavigation/MainMenu.vue
+++ b/aas-web-ui/src/components/AppNavigation/MainMenu.vue
@@ -262,6 +262,13 @@
         && (!selectedNode.value || Object.keys(selectedNode.value).length === 0)
       )
         return false
+      if (
+        moduleRoute?.meta?.routeModule
+        && Array.isArray(moduleRoute.meta.routeModule)
+        && moduleRoute.meta.routeModule.length > 0
+        && !moduleRoute.meta.routeModule.map(item => item.toLowerCase()).includes((route.name as string).toLowerCase())
+      )
+        return false
       return moduleRoute?.meta?.isVisibleModule === true || isActiveRoutePath(moduleRoute.path)
     })
 
@@ -273,6 +280,7 @@
         return moduleNameA.localeCompare(moduleNameB)
       },
     )
+
     return filteredAndOrderedModuleRoutes
   })
 

--- a/aas-web-ui/src/components/AppNavigation/MainMenu.vue
+++ b/aas-web-ui/src/components/AppNavigation/MainMenu.vue
@@ -248,7 +248,7 @@
   const smViewerEditor = computed(() => envStore.getSmViewerEditor) // Check the current environment allows showing the SM Viewer/Editor
   const selectedNode = computed(() => aasStore.getSelectedNode) // get selected AAS from Store
 
-  const filteredAndOrderedModuleRoutes = determineFilteredAndOrderedModuleRoutes()
+  const filteredAndOrderedModuleRoutes = computed(() => determineFilteredAndOrderedModuleRoutes())
 
   onMounted(async () => {
     scrollToSelectedModule()
@@ -266,7 +266,7 @@
   // Function to scroll to the active module
   function scrollToSelectedModule (): void {
     // Find the index of the selected item
-    const index = filteredAndOrderedModuleRoutes.findIndex((moduleRoute: RouteRecordRaw) =>
+    const index = filteredAndOrderedModuleRoutes.value.findIndex((moduleRoute: RouteRecordRaw) =>
       isActiveRoutePath(moduleRoute.path),
     )
 

--- a/aas-web-ui/src/composables/ModuleHandling.ts
+++ b/aas-web-ui/src/composables/ModuleHandling.ts
@@ -1,0 +1,78 @@
+import type { RouteRecordRaw } from 'vue-router'
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { useAASStore } from '@/store/AASDataStore'
+import { useNavigationStore } from '@/store/NavigationStore'
+
+interface ModuleHandling {
+  determineFilteredAndOrderedModuleRoutes: () => RouteRecordRaw[]
+  isActiveModuleRoute: (routePath: string) => boolean
+}
+
+export function useModuleHandling (): ModuleHandling {
+  // Vue Router
+  const route = useRoute()
+
+  // Stores
+  const navigationStore = useNavigationStore()
+  const aasStore = useAASStore()
+
+  // Computed Properties
+  const isMobile = computed(() => navigationStore.getIsMobile)
+  const moduleRoutes = computed(() => navigationStore.getModuleRoutes) // get the module routes
+  const selectedAas = computed(() => aasStore.getSelectedAAS) // get selected AAS from Store
+  const selectedNode = computed(() => aasStore.getSelectedNode) // get selected AAS from Store
+
+  function determineFilteredAndOrderedModuleRoutes () {
+    const filteredModuleRoutes = moduleRoutes.value.filter(
+      (moduleRoute: RouteRecordRaw) => {
+        if (isMobile.value && !moduleRoute?.meta?.isMobileModule) {
+          return false
+        }
+        if (!isMobile.value && !moduleRoute?.meta?.isDesktopModule) {
+          return false
+        }
+        if (
+          moduleRoute?.meta?.isOnlyVisibleWithSelectedAas
+          && (!selectedAas.value || Object.keys(selectedAas.value).length === 0)
+        ) {
+          return false
+        }
+        if (
+          moduleRoute?.meta?.isOnlyVisibleWithSelectedNode
+          && (!selectedNode.value || Object.keys(selectedNode.value).length === 0)
+        ) {
+          return false
+        }
+        if (
+          moduleRoute?.meta?.routeModule
+          && Array.isArray(moduleRoute.meta.routeModule)
+          && moduleRoute.meta.routeModule.length > 0
+          && !moduleRoute.meta.routeModule
+            .map(item => item)
+            .includes(route.name)
+        ) {
+          return false
+        }
+        return (
+          moduleRoute?.meta?.isVisibleModule === true
+          || isActiveModuleRoute(moduleRoute.path)
+        )
+      },
+    )
+
+    return filteredModuleRoutes.toSorted(
+      (moduleRouteA: RouteRecordRaw, moduleRouteB: RouteRecordRaw) => {
+        const moduleNameA: string = moduleRouteA?.name?.toString() || ''
+        const moduleNameB: string = moduleRouteB?.name?.toString() || ''
+        return moduleNameA.localeCompare(moduleNameB)
+      },
+    )
+  }
+
+  function isActiveModuleRoute (routePath: string): boolean {
+    return route.path === routePath || route.path.startsWith(`${routePath}/`)
+  }
+
+  return { determineFilteredAndOrderedModuleRoutes, isActiveModuleRoute }
+}

--- a/aas-web-ui/src/composables/ModuleHandling.ts
+++ b/aas-web-ui/src/composables/ModuleHandling.ts
@@ -21,7 +21,7 @@ export function useModuleHandling (): ModuleHandling {
   const isMobile = computed(() => navigationStore.getIsMobile)
   const moduleRoutes = computed(() => navigationStore.getModuleRoutes) // get the module routes
   const selectedAas = computed(() => aasStore.getSelectedAAS) // get selected AAS from Store
-  const selectedNode = computed(() => aasStore.getSelectedNode) // get selected AAS from Store
+  const selectedNode = computed(() => aasStore.getSelectedNode) // get selected node from Store
 
   function determineFilteredAndOrderedModuleRoutes () {
     const filteredModuleRoutes = moduleRoutes.value.filter(
@@ -45,12 +45,10 @@ export function useModuleHandling (): ModuleHandling {
           return false
         }
         if (
-          moduleRoute?.meta?.routeModule
-          && Array.isArray(moduleRoute.meta.routeModule)
-          && moduleRoute.meta.routeModule.length > 0
-          && !moduleRoute.meta.routeModule
-            .map(item => item)
-            .includes(route.name)
+          moduleRoute?.meta?.visibleOnRoutes
+          && Array.isArray(moduleRoute.meta.visibleOnRoutes)
+          && moduleRoute.meta.visibleOnRoutes.length > 0
+          && !moduleRoute.meta.visibleOnRoutes.includes(route.name)
         ) {
           return false
         }

--- a/aas-web-ui/src/pages/modules/TestVisibleForRoutes.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleForRoutes.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container class="pa-md-12">
+    <v-empty-state
+      icon="mdi-folder-open-outline"
+      text="This is a test module to showcase how to extend the AAS Web UI with new modules."
+      :title="moduleName + ' Module'"
+    >
+      <template #media>
+        <v-icon size="64" />
+      </template>
+    </v-empty-state>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+
+  defineOptions({
+    inheritAttrs: false,
+    routeModule: ['AASEditor', 'SMEditor'],
+  })
+
+  const moduleName = ref('TestVisibleForRoutes')
+</script>

--- a/aas-web-ui/src/pages/modules/TestVisibleForRoutes.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleForRoutes.vue
@@ -17,7 +17,7 @@
 
   defineOptions({
     inheritAttrs: false,
-    routeModule: ['AASEditor', 'SMEditor'],
+    visibleOnRoutes: ['AASEditor', 'SMEditor'],
   })
 
   const moduleName = ref('TestVisibleForRoutes')

--- a/aas-web-ui/src/router.ts
+++ b/aas-web-ui/src/router.ts
@@ -169,6 +169,7 @@ async function generateModuleRoutes (): Promise<Array<RouteRecordRaw>> {
     const isVisibleModule = moduleComponent.default?.isVisibleModule ?? true // Modules are per default visible
     const isOnlyVisibleWithSelectedAas = moduleComponent.default?.isOnlyVisibleWithSelectedAas ?? false
     const isOnlyVisibleWithSelectedNode = moduleComponent.default?.isOnlyVisibleWithSelectedNode ?? false
+    const routeModule = moduleComponent.default?.routeModule ?? []
     let preserveRouteQuery = moduleComponent.default?.preserveRouteQuery ?? false
 
     // Overwrite preserveRouteQuery
@@ -185,6 +186,7 @@ async function generateModuleRoutes (): Promise<Array<RouteRecordRaw>> {
       isVisibleModule,
       isOnlyVisibleWithSelectedAas,
       isOnlyVisibleWithSelectedNode,
+      routeModule,
       preserveRouteQuery,
     }
 

--- a/aas-web-ui/src/router.ts
+++ b/aas-web-ui/src/router.ts
@@ -169,7 +169,7 @@ async function generateModuleRoutes (): Promise<Array<RouteRecordRaw>> {
     const isVisibleModule = moduleComponent.default?.isVisibleModule ?? true // Modules are per default visible
     const isOnlyVisibleWithSelectedAas = moduleComponent.default?.isOnlyVisibleWithSelectedAas ?? false
     const isOnlyVisibleWithSelectedNode = moduleComponent.default?.isOnlyVisibleWithSelectedNode ?? false
-    const routeModule = moduleComponent.default?.routeModule ?? []
+    const visibleOnRoutes = moduleComponent.default?.visibleOnRoutes ?? []
     let preserveRouteQuery = moduleComponent.default?.preserveRouteQuery ?? false
 
     // Overwrite preserveRouteQuery
@@ -186,7 +186,7 @@ async function generateModuleRoutes (): Promise<Array<RouteRecordRaw>> {
       isVisibleModule,
       isOnlyVisibleWithSelectedAas,
       isOnlyVisibleWithSelectedNode,
-      routeModule,
+      visibleOnRoutes,
       preserveRouteQuery,
     }
 

--- a/aas-web-ui/src/utils/ModuleRouteUtils.ts
+++ b/aas-web-ui/src/utils/ModuleRouteUtils.ts
@@ -10,6 +10,7 @@ export type ModuleRouteMeta = {
   isVisibleModule?: boolean
   isOnlyVisibleWithSelectedAas?: boolean
   isOnlyVisibleWithSelectedNode?: boolean
+  routeModule?: Array<string>
   preserveRouteQuery?: boolean
 }
 

--- a/aas-web-ui/src/utils/ModuleRouteUtils.ts
+++ b/aas-web-ui/src/utils/ModuleRouteUtils.ts
@@ -10,7 +10,7 @@ export type ModuleRouteMeta = {
   isVisibleModule?: boolean
   isOnlyVisibleWithSelectedAas?: boolean
   isOnlyVisibleWithSelectedNode?: boolean
-  routeModule?: Array<string>
+  visibleOnRoutes?: Array<string>
   preserveRouteQuery?: boolean
 }
 

--- a/aas-web-ui/tests/composables/ModuleHandling.test.ts
+++ b/aas-web-ui/tests/composables/ModuleHandling.test.ts
@@ -1,0 +1,153 @@
+import type { RouteRecordRaw } from 'vue-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { computed, nextTick, reactive, ref } from 'vue'
+
+const mockState = {
+  route: reactive({
+    path: '/aaseditor',
+    name: 'AASEditor',
+  }),
+  isMobile: ref(false),
+  moduleRoutes: ref<Array<RouteRecordRaw>>([]),
+  selectedAas: ref<Record<string, unknown> | null>(null),
+  selectedNode: ref<Record<string, unknown> | null>(null),
+}
+
+async function importUseModuleHandling () {
+  vi.doMock('vue-router', async () => {
+    const actual = await vi.importActual('vue-router')
+    return {
+      ...actual,
+      useRoute: () => mockState.route,
+    }
+  })
+
+  vi.doMock('@/store/NavigationStore', () => ({
+    useNavigationStore: () => ({
+      get getIsMobile () {
+        return mockState.isMobile.value
+      },
+      get getModuleRoutes () {
+        return mockState.moduleRoutes.value
+      },
+    }),
+  }))
+
+  vi.doMock('@/store/AASDataStore', () => ({
+    useAASStore: () => ({
+      get getSelectedAAS () {
+        return mockState.selectedAas.value
+      },
+      get getSelectedNode () {
+        return mockState.selectedNode.value
+      },
+    }),
+  }))
+
+  return import('@/composables/ModuleHandling')
+}
+
+describe('ModuleHandling.ts', () => {
+  beforeEach(() => {
+    vi.resetModules()
+
+    mockState.route.path = '/aaseditor'
+    mockState.route.name = 'AASEditor'
+    mockState.isMobile.value = false
+    mockState.selectedAas.value = null
+    mockState.selectedNode.value = null
+    mockState.moduleRoutes.value = [
+      {
+        path: '/modules/test-module',
+        name: 'TestModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+        },
+      },
+    ]
+  })
+
+  it('includes a module when current route is allowed by visibleOnRoutes', async () => {
+    mockState.moduleRoutes.value = [
+      {
+        path: '/modules/allowed',
+        name: 'AllowedModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+          visibleOnRoutes: ['AASEditor', 'SMEditor'],
+        },
+      },
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(1)
+    expect(filteredRoutes[0].name).toBe('AllowedModule')
+  })
+
+  it('excludes a module when current route is not in visibleOnRoutes', async () => {
+    mockState.moduleRoutes.value = [
+      {
+        path: '/modules/restricted',
+        name: 'RestrictedModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+          visibleOnRoutes: ['SMEditor'],
+        },
+      },
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(0)
+  })
+
+  it('reacts to route name and store changes when wrapped in computed by callers', async () => {
+    mockState.moduleRoutes.value = [
+      {
+        path: '/modules/reactive',
+        name: 'ReactiveModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: false,
+          isVisibleModule: true,
+          isOnlyVisibleWithSelectedAas: true,
+          visibleOnRoutes: ['AASEditor'],
+        },
+      },
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = computed(() => determineFilteredAndOrderedModuleRoutes())
+
+    expect(filteredRoutes.value).toHaveLength(0)
+
+    mockState.selectedAas.value = { id: 'aas-1' }
+    await nextTick()
+    expect(filteredRoutes.value).toHaveLength(1)
+
+    mockState.route.name = 'SMEditor'
+    await nextTick()
+    expect(filteredRoutes.value).toHaveLength(0)
+
+    mockState.route.name = 'AASEditor'
+    mockState.isMobile.value = true
+    await nextTick()
+    expect(filteredRoutes.value).toHaveLength(0)
+
+    mockState.isMobile.value = false
+    await nextTick()
+    expect(filteredRoutes.value).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Description

This PR adds an optional `visibleOnRoutes` module option for controling the visibility of a module with respect to the current/active route.

For example, the newly added module `TestVisibleForRoutes` is just visible in the module list of the main menu if the current route equals the 'AASEditor' or 'SMEditor'.