### PR TITLE
Fixes title of `AASForm.vue`

### DIFF
--- a/aas-web-ui/src/components/EditorComponents/AASForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/AASForm.vue
@@ -1,8 +1,8 @@
 <template>
   <v-dialog v-model="editAASDialog" persistent width="860">
     <v-card>
-      <v-card-title>
-        <span class="text-body-large">{{ newShell ? 'Create a new AAS' : 'Edit AAS' }}</span>
+      <v-card-title class="bg-cardHeader">
+        {{ newShell ? 'Create a new AAS' : 'Edit AAS' }}
       </v-card-title>
 
       <v-divider />


### PR DESCRIPTION
This PR fixes the design of the title in `AASForm.vue` (to match the design of other dialogs)