### PR TITLE
Adds infrastructure config templates

### DIFF
--- a/aas-web-ui/public/config/basyx-infra.yml
+++ b/aas-web-ui/public/config/basyx-infra.yml
@@ -11,6 +11,12 @@
 # Optional component flags:
 # - hasRegistryIntegration: Backend repository creates/updates/deletes descriptors automatically.
 # - hasDiscoveryIntegration: Backend AAS registry creates/updates/deletes discovery asset links automatically.
+# Optional infrastructure template (defaults to "full" when omitted):
+# - full: aasDiscovery, aasRegistry, submodelRegistry, aasRepository, submodelRepository, conceptDescriptionRepository
+# - identifiable: aasRepository only; submodels are resolved via /shells/{aasId}/submodels/{submodelId}
+# - mono-repo: discovery and registries plus one aasEnvironment URL for the repositories
+# - mono-all: one aasEnvironment URL for all components
+# - catena-x: digitalTwinRegistry plus submodelService
 
 infrastructures:
   # Specify which infrastructure should be selected by default
@@ -19,6 +25,7 @@ infrastructures:
   # Local development infrastructure (no authentication)
   local:
     name: Local BaSyx
+    template: full
     components:
       aasDiscovery:
         baseUrl: "http://localhost:9084"
@@ -41,6 +48,7 @@ infrastructures:
   # # Production infrastructure with OAuth2 (Authorization Code Flow)
   # production:
   #   name: Production BaSyx
+  #   template: full
   #   components:
   #     aasDiscovery:
   #       baseUrl: "https://discovery.basyx.example.com"
@@ -67,6 +75,7 @@ infrastructures:
   # # Only use this for non-production scenarios or with proper secret management.
   # service:
   #   name: Service Account BaSyx
+  #   template: mono-repo
   #   components:
   #     aasDiscovery:
   #       baseUrl: "https://discovery.basyx.service.com"
@@ -74,11 +83,7 @@ infrastructures:
   #       baseUrl: "https://aasreg.basyx.service.com"
   #     submodelRegistry:
   #       baseUrl: "https://smreg.basyx.service.com"
-  #     aasRepository:
-  #       baseUrl: "https://aasenv.basyx.service.com"
-  #     submodelRepository:
-  #       baseUrl: "https://aasenv.basyx.service.com"
-  #     conceptDescriptionRepository:
+  #     aasEnvironment:
   #       baseUrl: "https://aasenv.basyx.service.com"
   #   security:
   #     type: oauth2
@@ -92,19 +97,12 @@ infrastructures:
   # # Infrastructure with Basic Authentication
   # staging:
   #   name: Staging BaSyx
+  #   template: catena-x
   #   components:
-  #     aasDiscovery:
-  #       baseUrl: "https://discovery.staging.basyx.com"
-  #     aasRegistry:
-  #       baseUrl: "https://aasreg.staging.basyx.com"
-  #     submodelRegistry:
-  #       baseUrl: "https://smreg.staging.basyx.com"
-  #     aasRepository:
-  #       baseUrl: "https://aasenv.staging.basyx.com"
-  #     submodelRepository:
-  #       baseUrl: "https://aasenv.staging.basyx.com"
-  #     conceptDescriptionRepository:
-  #       baseUrl: "https://aasenv.staging.basyx.com"
+  #     digitalTwinRegistry:
+  #       baseUrl: "https://dtr.staging.basyx.com"
+  #     submodelService:
+  #       baseUrl: "https://submodel-service.staging.basyx.com"
   #   security:
   #     type: basic
   #     config:
@@ -114,18 +112,9 @@ infrastructures:
   # # Infrastructure with Bearer Token
   # test:
   #   name: Test BaSyx
+  #   template: identifiable
   #   components:
-  #     aasDiscovery:
-  #       baseUrl: "https://discovery.test.basyx.com"
-  #     aasRegistry:
-  #       baseUrl: "https://aasreg.test.basyx.com"
-  #     submodelRegistry:
-  #       baseUrl: "https://smreg.test.basyx.com"
   #     aasRepository:
-  #       baseUrl: "https://aasenv.test.basyx.com"
-  #     submodelRepository:
-  #       baseUrl: "https://aasenv.test.basyx.com"
-  #     conceptDescriptionRepository:
   #       baseUrl: "https://aasenv.test.basyx.com"
   #   security:
   #     type: bearer

--- a/aas-web-ui/src/components/AppNavigation/AASList.vue
+++ b/aas-web-ui/src/components/AppNavigation/AASList.vue
@@ -597,7 +597,7 @@
   watch(
     () => triggerAASListReload.value,
     triggerVal => {
-      if (triggerVal === true) {
+      if (triggerVal > 0) {
         initialize()
       }
     },

--- a/aas-web-ui/src/components/AppNavigation/AASList.vue
+++ b/aas-web-ui/src/components/AppNavigation/AASList.vue
@@ -523,7 +523,8 @@
   const isSearchLimited = computed(() => searchValue.value.trim() !== '' && hasMorePages.value)
 
   // Watchers
-  // Reload when AAS Registry URL or selected infrastructure changes
+  // Reload when AAS Registry URL or selected infrastructure changes.
+  // Use post-flush so infrastructure-switch clear signals reset pagination before the reload starts.
   watch(
     [() => aasRegistryURL.value, () => aasRepoURL.value, () => selectedInfrastructureId.value],
     ([newRegistryUrl, newRepoUrl, newId], [oldRegistryUrl, oldRepoUrl, oldId]) => {
@@ -540,7 +541,7 @@
         initialize()
       }
     },
-    { immediate: true },
+    { immediate: true, flush: 'post' },
   )
 
   watch(
@@ -604,12 +605,10 @@
 
   watch(
     () => clearAASList.value,
-    clearAasListValue => {
-      if (clearAasListValue === true) {
-        invalidatePaginationGeneration()
-        resetAASListState(false)
-        unbindVirtualScrollListener()
-      }
+    () => {
+      invalidatePaginationGeneration()
+      resetAASListState(false)
+      unbindVirtualScrollListener()
     },
   )
 

--- a/aas-web-ui/src/components/AppNavigation/DeleteAAS.vue
+++ b/aas-web-ui/src/components/AppNavigation/DeleteAAS.vue
@@ -62,6 +62,7 @@
   import { useAASStore } from '@/store/AASDataStore'
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
+  import { isComponentActiveForTemplate } from '@/utils/InfrastructureUtils'
 
   // Vue Router
   const route = useRoute()
@@ -96,14 +97,30 @@
   const selected = ref<string[]>([]) // Variable to store the selected Submodel Ids
 
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
+  const aasRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'AASRegistry'),
+  )
+  const submodelRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'SubmodelRegistry'),
+  )
+  const aasDiscoveryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'AASDiscovery'),
+  )
   const aasRepoHasRegistryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.AASRepo?.hasRegistryIntegration ?? true,
+    () =>
+      !aasRegistryActive.value
+      || (selectedInfrastructure.value?.components?.AASRepo?.hasRegistryIntegration ?? true),
   )
   const submodelRepoHasRegistryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true,
+    () =>
+      !submodelRegistryActive.value
+      || (selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true),
   )
   const aasRegistryHasDiscoveryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.AASRegistry?.hasDiscoveryIntegration ?? true,
+    () =>
+      !aasRegistryActive.value
+      || !aasDiscoveryActive.value
+      || (selectedInfrastructure.value?.components?.AASRegistry?.hasDiscoveryIntegration ?? true),
   )
 
   watch(
@@ -119,7 +136,7 @@
 
         for (const submodelRef of submodelRefs) {
           // TODO: Optimize by only using the metadata endpoint once it is implemented in BaSyx Go
-          const submodel = await fetchSmById(submodelRef.keys[0].value)
+          const submodel = await fetchSmById(submodelRef.keys[0].value, false, false, props.aas.id)
           submodelIds.value.push({ smId: submodelRef.keys[0].value, smIdShort: submodel.idShort, submodel })
           selected.value.push(submodelRef.keys[0].value)
         }
@@ -148,7 +165,7 @@
         const submodelIds = selected.value
         // Remove each submodel
         for (const submodelId of submodelIds) {
-          error = error || !(await deleteSmById(submodelId))
+          error = error || !(await deleteSmById(submodelId, props.aas.id))
           if (!error && !submodelRepoHasRegistryIntegration.value) {
             const descriptorDeleted = await deleteSubmodelDescriptor(submodelId)
             if (!descriptorDeleted) {

--- a/aas-web-ui/src/components/AppNavigation/Settings/ComponentConfigPanel.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/ComponentConfigPanel.vue
@@ -19,9 +19,7 @@
                 ? 'success'
                 : getFieldConnectionStatus(endpointField) === false
                   ? 'error'
-                  : getEndpointFieldValue(components, endpointField)
-                    ? 'grey'
-                    : 'grey'
+                  : 'grey'
             "
             size="small"
           >

--- a/aas-web-ui/src/components/AppNavigation/Settings/ComponentConfigPanel.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/ComponentConfigPanel.vue
@@ -1,36 +1,36 @@
 <template>
   <v-container class="pa-0">
-    <div v-for="componentKey in BASYX_COMPONENT_KEYS" :key="componentKey" class="mb-2">
+    <div v-for="endpointField in endpointFields" :key="endpointField.key" class="mb-2">
       <v-text-field
         autocomplete="url"
         density="compact"
-        :label="getComponentLabel(componentKey) + ' Endpoint URL'"
-        :model-value="components[componentKey].url"
-        :name="`basyx-${componentKey}-endpoint`"
+        :label="endpointField.label + ' Endpoint URL'"
+        :model-value="getEndpointFieldValue(components, endpointField)"
+        :name="`basyx-${endpointField.key}-endpoint`"
         placeholder="https://example.com/api"
         variant="outlined"
-        @keyup.enter="$emit('test-connection', componentKey)"
-        @update:model-value="handleUrlUpdate(componentKey, $event)"
+        @keyup.enter="$emit('test-connection', endpointField.key)"
+        @update:model-value="handleUrlUpdate(endpointField, $event)"
       >
         <template #prepend-inner>
           <v-icon
             :color="
-              componentConnectionStatus[componentKey] === true
+              getFieldConnectionStatus(endpointField) === true
                 ? 'success'
-                : componentConnectionStatus[componentKey] === false
+                : getFieldConnectionStatus(endpointField) === false
                   ? 'error'
-                  : components[componentKey].url
+                  : getEndpointFieldValue(components, endpointField)
                     ? 'grey'
                     : 'grey'
             "
             size="small"
           >
             {{
-              componentConnectionStatus[componentKey] === true
+              getFieldConnectionStatus(endpointField) === true
                 ? 'mdi-check-circle'
-                : componentConnectionStatus[componentKey] === false
+                : getFieldConnectionStatus(endpointField) === false
                   ? 'mdi-alert-circle'
-                  : components[componentKey].url
+                  : getEndpointFieldValue(components, endpointField)
                     ? 'mdi-help-circle'
                     : 'mdi-circle-outline'
             }}
@@ -39,12 +39,12 @@
 
         <template #append-inner>
           <v-btn
-            :disabled="!components[componentKey].url"
+            :disabled="!getEndpointFieldValue(components, endpointField)"
             icon
-            :loading="componentTestingLoading[componentKey]"
+            :loading="isFieldTesting(endpointField)"
             size="x-small"
             variant="text"
-            @click.stop="$emit('test-connection', componentKey)"
+            @click.stop="$emit('test-connection', endpointField.key)"
           >
             <v-icon>mdi-connection</v-icon>
             <v-tooltip activator="parent" location="bottom"> Test Connection </v-tooltip>
@@ -52,25 +52,27 @@
         </template>
       </v-text-field>
 
-      <v-checkbox
-        v-if="componentKey === 'AASRepo' || componentKey === 'SubmodelRepo'"
-        class="mt-n1 mb-1"
-        density="compact"
-        hide-details
-        label="Backend creates descriptors automatically"
-        :model-value="components[componentKey].hasRegistryIntegration ?? true"
-        @update:model-value="handleRegistryIntegrationUpdate(componentKey, $event)"
-      />
+      <template v-for="componentKey in getIntegrationComponentKeys(endpointField)" :key="componentKey">
+        <v-checkbox
+          v-if="componentKey === 'AASRepo' || componentKey === 'SubmodelRepo'"
+          class="mt-n1 mb-1"
+          density="compact"
+          hide-details
+          :label="getRegistryIntegrationLabel(componentKey)"
+          :model-value="components[componentKey].hasRegistryIntegration ?? true"
+          @update:model-value="handleRegistryIntegrationUpdate(componentKey, $event)"
+        />
 
-      <v-checkbox
-        v-if="componentKey === 'AASRegistry'"
-        class="mt-n1 mb-1"
-        density="compact"
-        hide-details
-        label="Backend creates AAS discovery asset links automatically"
-        :model-value="components[componentKey].hasDiscoveryIntegration ?? true"
-        @update:model-value="handleDiscoveryIntegrationUpdate(componentKey, $event)"
-      />
+        <v-checkbox
+          v-if="componentKey === 'AASRegistry'"
+          class="mt-n1 mb-1"
+          density="compact"
+          hide-details
+          label="Backend creates AAS discovery asset links automatically"
+          :model-value="components[componentKey].hasDiscoveryIntegration ?? true"
+          @update:model-value="handleDiscoveryIntegrationUpdate(componentKey, $event)"
+        />
+      </template>
     </div>
   </v-container>
 </template>
@@ -81,28 +83,75 @@
     ComponentConnectionStatus,
     ComponentTestingLoading,
     InfrastructureConfig,
+    InfrastructureTemplate,
   } from '@/types/Infrastructure'
-  import { BASYX_COMPONENT_KEYS, getComponentLabel } from '@/utils/InfrastructureUtils'
+  import type {
+    InfrastructureEndpointField,
+    InfrastructureEndpointFieldKey,
+  } from '@/utils/InfrastructureUtils'
+  import { computed } from 'vue'
+  import {
+    getEndpointFieldsForTemplate,
+    getEndpointFieldValue,
+    isComponentActiveForTemplate,
+  } from '@/utils/InfrastructureUtils'
 
   // Props
-  defineProps<{
+  const props = defineProps<{
     components: InfrastructureConfig['components']
+    template: InfrastructureTemplate
     componentConnectionStatus: ComponentConnectionStatus
     componentTestingLoading: ComponentTestingLoading
   }>()
 
   // Emits
   const emit = defineEmits<{
-    'test-connection': [componentKey: BaSyxComponentKey]
+    'test-connection': [fieldKey: InfrastructureEndpointFieldKey]
     'update:component-url': [componentKey: BaSyxComponentKey, url: string]
     'update:connection-status': [componentKey: BaSyxComponentKey, status: boolean | null]
     'update:registry-integration': [componentKey: BaSyxComponentKey, enabled: boolean]
     'update:discovery-integration': [componentKey: BaSyxComponentKey, enabled: boolean]
   }>()
 
-  function handleUrlUpdate (componentKey: BaSyxComponentKey, url: string): void {
-    emit('update:component-url', componentKey, url)
-    emit('update:connection-status', componentKey, null)
+  const endpointFields = computed(() => getEndpointFieldsForTemplate(props.template))
+
+  function handleUrlUpdate (endpointField: InfrastructureEndpointField, url: string): void {
+    for (const componentKey of endpointField.componentKeys) {
+      emit('update:component-url', componentKey, url)
+      emit('update:connection-status', componentKey, null)
+    }
+  }
+
+  function getFieldConnectionStatus (endpointField: InfrastructureEndpointField): boolean | null {
+    const statuses = endpointField.componentKeys.map(key => props.componentConnectionStatus[key])
+
+    if (statuses.every(status => status === true)) {
+      return true
+    }
+
+    if (statuses.includes(false)) {
+      return false
+    }
+
+    return null
+  }
+
+  function isFieldTesting (endpointField: InfrastructureEndpointField): boolean {
+    return endpointField.componentKeys.some(key => props.componentTestingLoading[key])
+  }
+
+  function getIntegrationComponentKeys (endpointField: InfrastructureEndpointField): BaSyxComponentKey[] {
+    return endpointField.componentKeys.filter(componentKey =>
+      (componentKey === 'AASRepo' && isComponentActiveForTemplate(props.template, 'AASRegistry'))
+      || (componentKey === 'SubmodelRepo' && isComponentActiveForTemplate(props.template, 'SubmodelRegistry'))
+      || (componentKey === 'AASRegistry' && isComponentActiveForTemplate(props.template, 'AASDiscovery')),
+    )
+  }
+
+  function getRegistryIntegrationLabel (componentKey: BaSyxComponentKey): string {
+    return componentKey === 'AASRepo'
+      ? 'Backend creates AAS descriptors automatically'
+      : 'Backend creates Submodel descriptors automatically'
   }
 
   function handleRegistryIntegrationUpdate (componentKey: BaSyxComponentKey, value: boolean | null): void {

--- a/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureListTable.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureListTable.vue
@@ -34,7 +34,10 @@
             </td>
 
             <td>
-              <span class="text-body-small opacity-60">{{ getInfrastructureSummary(infra) }}</span>
+              <div class="d-flex flex-column">
+                <span class="text-body-small">{{ getInfrastructureTemplateDefinition(infra).label }}</span>
+                <span class="text-body-small opacity-60">{{ getInfrastructureSummary(infra) }}</span>
+              </div>
             </td>
 
             <td style="width: 120px">
@@ -75,7 +78,7 @@
 <script lang="ts" setup>
   import type { InfrastructureConfig } from '@/types/Infrastructure'
   import { computed } from 'vue'
-  import { getInfrastructureSummary } from '@/utils/InfrastructureUtils'
+  import { getInfrastructureSummary, getInfrastructureTemplateDefinition } from '@/utils/InfrastructureUtils'
 
   // Props
   const props = defineProps<{

--- a/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureManagement.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureManagement.vue
@@ -84,12 +84,41 @@
             />
 
             <v-divider />
+
+            <v-list-subheader class="mb-1">Infrastructure Template</v-list-subheader>
+
+            <v-select
+              v-model="editingInfrastructure.template"
+              bg-color="surface-light"
+              class="mb-2"
+              density="compact"
+              flat
+              item-title="label"
+              item-value="value"
+              :items="infrastructureTemplateOptions"
+              label="Template"
+              :rules="[requiredRule]"
+              variant="outlined"
+              @update:model-value="handleTemplateUpdate"
+            />
+
+            <v-alert
+              class="mb-3"
+              density="compact"
+              type="info"
+              variant="tonal"
+            >
+              {{ selectedTemplateDescription }}
+            </v-alert>
+
+            <v-divider />
             <v-list-subheader class="mb-3">Component Endpoints</v-list-subheader>
             <!-- Component Configurations -->
             <ComponentConfigPanel
               :component-connection-status="componentConnectionStatus"
               :component-testing-loading="componentTestingLoading"
               :components="editingInfrastructure.components"
+              :template="editingInfrastructure.template"
               @test-connection="testComponentConnection"
               @update:component-url="handleComponentUrlUpdate"
               @update:connection-status="handleConnectionStatusUpdate"
@@ -219,7 +248,13 @@
 
 <script lang="ts" setup>
   import type { BaSyxComponentKey } from '@/types/BaSyx'
-  import type { AuthFlowOption, InfrastructureConfig, SecurityType } from '@/types/Infrastructure'
+  import type {
+    AuthFlowOption,
+    InfrastructureConfig,
+    InfrastructureTemplate,
+    SecurityType,
+  } from '@/types/Infrastructure'
+  import type { InfrastructureEndpointFieldKey } from '@/utils/InfrastructureUtils'
   import { computed, ref, toRaw, watch } from 'vue'
   import { useRouter } from 'vue-router'
   import { useAuth } from '@/composables/Auth/useAuth'
@@ -228,7 +263,12 @@
   import { useComponentConnectionTesting } from '@/composables/Infrastructure/useComponentConnectionTesting'
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
-  import { requiredRule } from '@/utils/InfrastructureUtils'
+  import {
+    getInfrastructureTemplateDefinition,
+    INFRASTRUCTURE_TEMPLATE_OPTIONS,
+    normalizeInfrastructureTemplate,
+    requiredRule,
+  } from '@/utils/InfrastructureUtils'
 
   // Props
   const props = defineProps<{
@@ -297,6 +337,10 @@
   const componentConnectionStatus = connectionTesting.componentConnectionStatus
   const componentTestingLoading = connectionTesting.componentTestingLoading
   const testingAllConnections = connectionTesting.testingAllConnections
+  const infrastructureTemplateOptions = INFRASTRUCTURE_TEMPLATE_OPTIONS
+  const selectedTemplateDescription = computed(
+    () => getInfrastructureTemplateDefinition(editingInfrastructure.value.template).description,
+  )
 
   const router = useRouter()
 
@@ -401,15 +445,26 @@
     resetDialogOpen.value = false
   }
 
-  // Test individual component connection
-  async function testComponentConnection (componentKey: BaSyxComponentKey): Promise<void> {
-    const url = editingInfrastructure.value.components[componentKey].url
-    await connectionTesting.testComponentConnection(componentKey, url)
+  // Test individual endpoint field connection
+  async function testComponentConnection (fieldKey: InfrastructureEndpointFieldKey): Promise<void> {
+    await connectionTesting.testEndpointField(
+      editingInfrastructure.value.template,
+      fieldKey,
+      editingInfrastructure.value.components,
+    )
   }
 
   // Test all component connections for the currently edited infrastructure
   async function testAllConnections (): Promise<void> {
-    await connectionTesting.testAllConnections(editingInfrastructure.value.components)
+    await connectionTesting.testAllConnections(
+      editingInfrastructure.value.components,
+      editingInfrastructure.value.template,
+    )
+  }
+
+  function handleTemplateUpdate (template: InfrastructureTemplate | string): void {
+    editingInfrastructure.value.template = normalizeInfrastructureTemplate(template)
+    connectionTesting.resetConnectionStatus()
   }
 
   async function authenticateOAuth2 (): Promise<void> {

--- a/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureManagement.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureManagement.vue
@@ -264,10 +264,13 @@
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
   import {
+    getEndpointFieldsForTemplate,
+    getEndpointFieldValue,
     getInfrastructureTemplateDefinition,
     INFRASTRUCTURE_TEMPLATE_OPTIONS,
     normalizeInfrastructureTemplate,
     requiredRule,
+    setEndpointFieldValue,
   } from '@/utils/InfrastructureUtils'
 
   // Props
@@ -411,6 +414,8 @@
     const { valid } = await formRef.value.validate()
     if (!valid) return
 
+    normalizeGroupedEndpointFields(editingInfrastructure.value)
+
     // Save auth data
     await saveAuthDataToInfrastructure(editingInfrastructure.value)
 
@@ -464,7 +469,22 @@
 
   function handleTemplateUpdate (template: InfrastructureTemplate | string): void {
     editingInfrastructure.value.template = normalizeInfrastructureTemplate(template)
+    normalizeGroupedEndpointFields(editingInfrastructure.value)
     connectionTesting.resetConnectionStatus()
+  }
+
+  function normalizeGroupedEndpointFields (infra: InfrastructureConfig): void {
+    for (const endpointField of getEndpointFieldsForTemplate(infra)) {
+      if (endpointField.componentKeys.length <= 1) {
+        continue
+      }
+
+      setEndpointFieldValue(
+        infra.components,
+        endpointField,
+        getEndpointFieldValue(infra.components, endpointField),
+      )
+    }
   }
 
   async function authenticateOAuth2 (): Promise<void> {

--- a/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureSelector.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureSelector.vue
@@ -32,6 +32,7 @@
   import { useRouter } from 'vue-router'
   import { useEnvStore } from '@/store/EnvironmentStore'
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
+  import { getActiveComponentKeys } from '@/utils/InfrastructureUtils'
 
   // Stores
   const infrastructureStore = useInfrastructureStore()
@@ -47,6 +48,7 @@
   // Computed Properties
   const infrastructures = computed(() => infrastructureStore.getInfrastructures)
   const basyxComponents = computed(() => infrastructureStore.getBasyxComponents)
+  const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
   const endpointConfigAvailable = computed(() => envStore.getEndpointConfigAvailable)
 
   // Local State
@@ -62,7 +64,8 @@
 
   // Compute connection status based on connected components
   const connectionStatus = computed(() => {
-    const components = Object.values(basyxComponents.value)
+    const activeKeys = getActiveComponentKeys(selectedInfrastructure.value)
+    const components = activeKeys.map(key => basyxComponents.value[key])
     const connectedCount = components.filter(comp => comp.connected === true).length
     const hasFailures = components.some(comp => comp.connected === false)
     const hasUnknown = components.some(comp => comp.connected === null)

--- a/aas-web-ui/src/components/AppNavigation/UploadAAS.vue
+++ b/aas-web-ui/src/components/AppNavigation/UploadAAS.vue
@@ -108,6 +108,11 @@
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
   import { Endpoint, ProtocolInformation } from '@/types/Descriptors'
+  import {
+    getDefaultAasUploadMode,
+    type InfrastructureAasUploadMode,
+    isComponentActiveForTemplate,
+  } from '@/utils/InfrastructureUtils'
   import { useAASXImport } from '../../composables/AAS/AASXImport'
 
   // Stores
@@ -142,7 +147,7 @@
   const ignoreDuplicates = ref(true)
   const uploadProgress = ref(0)
   const currentFileLabel = ref('')
-  const uploadMode = ref<'client' | 'server'>('client')
+  const uploadMode = ref<InfrastructureAasUploadMode>('client')
 
   const uploadModes = [
     { title: 'Client-side Import', value: 'client' },
@@ -174,14 +179,31 @@
   })
 
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
+  const defaultUploadMode = computed(() => getDefaultAasUploadMode(selectedInfrastructure.value))
+  const aasRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'AASRegistry'),
+  )
+  const submodelRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'SubmodelRegistry'),
+  )
+  const aasDiscoveryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'AASDiscovery'),
+  )
   const aasRepoHasRegistryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.AASRepo?.hasRegistryIntegration ?? true,
+    () =>
+      !aasRegistryActive.value
+      || (selectedInfrastructure.value?.components?.AASRepo?.hasRegistryIntegration ?? true),
   )
   const submodelRepoHasRegistryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true,
+    () =>
+      !submodelRegistryActive.value
+      || (selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true),
   )
   const aasRegistryHasDiscoveryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.AASRegistry?.hasDiscoveryIntegration ?? true,
+    () =>
+      !aasRegistryActive.value
+      || !aasDiscoveryActive.value
+      || (selectedInfrastructure.value?.components?.AASRegistry?.hasDiscoveryIntegration ?? true),
   )
   const manualDescriptorSyncRequired = computed(
     () => !aasRepoHasRegistryIntegration.value || !submodelRepoHasRegistryIntegration.value,
@@ -191,6 +213,9 @@
   watch(
     () => props.modelValue,
     value => {
+      if (value) {
+        uploadMode.value = defaultUploadMode.value
+      }
       uploadAASDialog.value = value
     },
   )
@@ -367,7 +392,7 @@
     loadingUpload.value = false
     uploadProgress.value = 0
     currentFileLabel.value = ''
-    uploadMode.value = 'client'
+    uploadMode.value = defaultUploadMode.value
   }
 
   function createEndpoints (href: string, type: string): Array<Endpoint> {

--- a/aas-web-ui/src/components/AppNavigation/UploadAAS.vue
+++ b/aas-web-ui/src/components/AppNavigation/UploadAAS.vue
@@ -179,7 +179,15 @@
   })
 
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
-  const defaultUploadMode = computed(() => getDefaultAasUploadMode(selectedInfrastructure.value))
+  function allSelectedFilesAreAasx (): boolean {
+    return aasFiles.value.length > 0
+      && aasFiles.value.every(file => detectImportFileKind(file.name) === 'aasx')
+  }
+
+  const defaultUploadMode = computed<InfrastructureAasUploadMode>(() => {
+    const infrastructureDefault = getDefaultAasUploadMode(selectedInfrastructure.value)
+    return infrastructureDefault === 'server' && allSelectedFilesAreAasx() ? 'server' : 'client'
+  })
   const aasRegistryActive = computed(() =>
     isComponentActiveForTemplate(selectedInfrastructure.value, 'AASRegistry'),
   )
@@ -224,6 +232,15 @@
     () => uploadAASDialog.value,
     value => {
       emit('update:model-value', value)
+    },
+  )
+
+  watch(
+    () => aasFiles.value.map(file => file.name),
+    () => {
+      if (uploadAASDialog.value && !loadingUpload.value) {
+        uploadMode.value = defaultUploadMode.value
+      }
     },
   )
 

--- a/aas-web-ui/src/components/EditorComponents/AASForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/AASForm.vue
@@ -240,6 +240,7 @@
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
   import { Endpoint, ProtocolInformation } from '@/types/Descriptors'
+  import { isComponentActiveForTemplate } from '@/utils/InfrastructureUtils'
 
   const props = defineProps<{
     modelValue: boolean
@@ -307,11 +308,22 @@
   // Computed Properties
   const selectedAAS = computed(() => aasStore.getSelectedAAS) // Get the selected AAS from Store
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
+  const aasRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'AASRegistry'),
+  )
+  const aasDiscoveryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'AASDiscovery'),
+  )
   const aasRepoHasRegistryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.AASRepo?.hasRegistryIntegration ?? true,
+    () =>
+      !aasRegistryActive.value
+      || (selectedInfrastructure.value?.components?.AASRepo?.hasRegistryIntegration ?? true),
   )
   const aasRegistryHasDiscoveryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.AASRegistry?.hasDiscoveryIntegration ?? true,
+    () =>
+      !aasRegistryActive.value
+      || !aasDiscoveryActive.value
+      || (selectedInfrastructure.value?.components?.AASRegistry?.hasDiscoveryIntegration ?? true),
   )
   const bordersToShow = computed(() => (panel: number) => {
     let border = ''

--- a/aas-web-ui/src/components/EditorComponents/DeleteDialog.vue
+++ b/aas-web-ui/src/components/EditorComponents/DeleteDialog.vue
@@ -44,6 +44,7 @@
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
   import { extractEndpointHref } from '@/utils/AAS/DescriptorUtils'
+  import { isComponentActiveForTemplate } from '@/utils/InfrastructureUtils'
 
   const aasStore = useAASStore()
   const infrastructureStore = useInfrastructureStore()
@@ -72,8 +73,17 @@
 
   const selectedAAS = computed(() => aasStore.getSelectedAAS) // get selected AAS from Store
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
+  const submodelRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'SubmodelRegistry'),
+  )
   const submodelRepoHasRegistryIntegration = computed(
     () => selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true,
+  )
+  const shouldResolveSubmodelWithRegistry = computed(
+    () => submodelRegistryActive.value && submodelRepoHasRegistryIntegration.value,
+  )
+  const manualSubmodelDescriptorSyncRequired = computed(
+    () => submodelRegistryActive.value && !submodelRepoHasRegistryIntegration.value,
   )
 
   watch(
@@ -95,7 +105,7 @@
     let deleteSucceeded = false
     if (props.element.modelType === 'Submodel') {
       let smEndpoint = ''
-      if (submodelRepoHasRegistryIntegration.value) {
+      if (shouldResolveSubmodelWithRegistry.value) {
         const smDescriptor = await fetchSmDescriptor(props.element.id)
         smEndpoint = extractEndpointHref(smDescriptor, 'SUBMODEL-3.0')
         if (!smEndpoint) {
@@ -136,7 +146,7 @@
           return
         }
 
-        if (!submodelRepoHasRegistryIntegration.value) {
+        if (manualSubmodelDescriptorSyncRequired.value) {
           const descriptorDeleted = await deleteSubmodelDescriptor(props.element.id)
           if (!descriptorDeleted) {
             navigationStore.dispatchSnackbar({

--- a/aas-web-ui/src/components/EditorComponents/JsonInsert.vue
+++ b/aas-web-ui/src/components/EditorComponents/JsonInsert.vue
@@ -44,6 +44,7 @@
   import { Endpoint, ProtocolInformation } from '@/types/Descriptors'
   import { getCreatedSubmodelElementPath, isDataElementModelType } from '@/utils/AAS/SubmodelElementPathUtils'
   import { base64Decode } from '@/utils/EncodeDecodeUtils'
+  import { isComponentActiveForTemplate } from '@/utils/InfrastructureUtils'
 
   const props = defineProps<{
     modelValue: boolean
@@ -87,8 +88,13 @@
   // Computed Properties
   const selectedAAS = computed(() => aasStore.getSelectedAAS) // Get the selected AAS from Store
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
+  const submodelRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'SubmodelRegistry'),
+  )
   const submodelRepoHasRegistryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true,
+    () =>
+      !submodelRegistryActive.value
+      || (selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true),
   )
 
   watch(

--- a/aas-web-ui/src/components/EditorComponents/SubmodelForm.vue
+++ b/aas-web-ui/src/components/EditorComponents/SubmodelForm.vue
@@ -204,6 +204,7 @@
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
   import { Endpoint, ProtocolInformation } from '@/types/Descriptors'
+  import { isComponentActiveForTemplate } from '@/utils/InfrastructureUtils'
 
   const props = defineProps<{
     modelValue: boolean
@@ -266,8 +267,13 @@
   const selectedNode = computed(() => aasStore.getSelectedNode) // Get the selected AAS from Store
   const selectedAAS = computed(() => aasStore.getSelectedAAS) // Get the selected AAS from Store
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
+  const submodelRegistryActive = computed(() =>
+    isComponentActiveForTemplate(selectedInfrastructure.value, 'SubmodelRegistry'),
+  )
   const submodelRepoHasRegistryIntegration = computed(
-    () => selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true,
+    () =>
+      !submodelRegistryActive.value
+      || (selectedInfrastructure.value?.components?.SubmodelRepo?.hasRegistryIntegration ?? true),
   )
   const bordersToShow = computed(() => (panel: number) => {
     let border = ''

--- a/aas-web-ui/src/components/SubmodelTree.vue
+++ b/aas-web-ui/src/components/SubmodelTree.vue
@@ -493,7 +493,7 @@
   watch(
     () => triggerTreeviewReload.value,
     triggerVal => {
-      if (triggerVal === true && !isAuthenticating.value) {
+      if (triggerVal > 0 && !isAuthenticating.value) {
         initialize()
       }
     },

--- a/aas-web-ui/src/composables/AAS/AASHandling.ts
+++ b/aas-web-ui/src/composables/AAS/AASHandling.ts
@@ -469,7 +469,7 @@ export function useAASHandling () {
 
       const submodelPromises = submodelRefs.map((submodelRef: any) => {
         const smId = extractIdFromReference(submodelRef, 'Submodel')
-        return fetchSmById(smId, false, true)
+        return fetchSmById(smId, false, true, aasId)
       })
 
       return await Promise.all(submodelPromises)

--- a/aas-web-ui/src/composables/AAS/AASXImport.ts
+++ b/aas-web-ui/src/composables/AAS/AASXImport.ts
@@ -6,6 +6,8 @@ import { useSMEFile } from '@/composables/AAS/SubmodelElements/File'
 import { useAASRepositoryClient } from '@/composables/Client/AASRepositoryClient'
 import { useCDRepositoryClient } from '@/composables/Client/CDRepositoryClient'
 import { useSMRepositoryClient } from '@/composables/Client/SMRepositoryClient'
+import { useInfrastructureStore } from '@/store/InfrastructureStore'
+import { usesSubmodelSuperpath } from '@/utils/InfrastructureUtils'
 import { safeSegment } from '@/utils/StringUtils'
 
 type JsonRecord = Record<string, unknown>
@@ -376,6 +378,7 @@ export function useAASXImport (): {
   const { postSubmodel, putSubmodel, putAttachmentFile, getSmEndpointById } = useSMRepositoryClient()
   const { postConceptDescription, putConceptDescription } = useCDRepositoryClient()
   const { determineContentType } = useSMEFile()
+  const infrastructureStore = useInfrastructureStore()
 
   function parseEnvironmentText (environmentText: string, sourceLabel: string): JsonRecord {
     const trimmedText = environmentText.trim()
@@ -531,12 +534,12 @@ export function useAASXImport (): {
     return await putConceptDescription(conceptDescription)
   }
 
-  async function upsertSubmodel (submodel: aasCore.types.Submodel): Promise<boolean> {
-    const created = await postSubmodel(submodel)
+  async function upsertSubmodel (submodel: aasCore.types.Submodel, aasId?: string): Promise<boolean> {
+    const created = await postSubmodel(submodel, false, aasId)
     if (created) {
       return true
     }
-    return await putSubmodel(submodel)
+    return await putSubmodel(submodel, false, aasId)
   }
 
   async function upsertAas (aas: aasCore.types.AssetAdministrationShell): Promise<boolean> {
@@ -547,7 +550,49 @@ export function useAASXImport (): {
     return await putAas(aas)
   }
 
+  function aasReferencesSubmodel (aas: JsonRecord, submodelId: string): boolean {
+    return asArray(aas.submodels).some(submodelRef => {
+      const reference = asRecord(submodelRef)
+      if (!reference) {
+        return false
+      }
+
+      return asArray(reference.keys).some(key => asString(asRecord(key)?.value).trim() === submodelId)
+    })
+  }
+
+  function findAasIdForSubmodel (parsedPackage: ParsedAASX, submodelId: string): string | undefined {
+    for (const { json } of parsedPackage.aasById.values()) {
+      const aasId = asString(json.id).trim()
+      if (aasId !== '' && aasReferencesSubmodel(json, submodelId)) {
+        return aasId
+      }
+    }
+
+    if (parsedPackage.aasById.size === 1) {
+      const onlyAas = Array.from(parsedPackage.aasById.values())[0]
+      const aasId = asString(onlyAas?.json.id).trim()
+      return aasId === '' ? undefined : aasId
+    }
+
+    return undefined
+  }
+
   async function importParsedPackage (parsedPackage: ParsedAASX, warnings: string[]): Promise<ClientAASXImportResult> {
+    const useSuperpath = usesSubmodelSuperpath(infrastructureStore.getSelectedInfrastructure)
+    const importedAasIds: string[] = []
+
+    async function upsertParsedAasEntries (): Promise<void> {
+      for (const { core: aas, json } of parsedPackage.aasById.values()) {
+        const success = await upsertAas(aas)
+        if (success) {
+          importedAasIds.push(asString(json.id))
+        } else {
+          warnings.push(`Failed to create or update AAS '${asString(json.id)}'.`)
+        }
+      }
+    }
+
     for (const { core: conceptDescription, json } of parsedPackage.cdById.values()) {
       const success = await upsertConceptDescription(conceptDescription)
       if (!success) {
@@ -555,25 +600,32 @@ export function useAASXImport (): {
       }
     }
 
+    if (useSuperpath) {
+      await upsertParsedAasEntries()
+    }
+
     for (const { core: submodel, json } of parsedPackage.submodelById.values()) {
-      const success = await upsertSubmodel(submodel)
+      const submodelId = asString(json.id).trim()
+      const aasId = useSuperpath ? findAasIdForSubmodel(parsedPackage, submodelId) : undefined
+
+      if (useSuperpath && !aasId) {
+        warnings.push(`Failed to create or update Submodel '${submodelId}': no referencing AAS found.`)
+        continue
+      }
+
+      const success = await upsertSubmodel(submodel, aasId)
       if (!success) {
-        warnings.push(`Failed to create or update Submodel '${asString(json.id)}'.`)
+        warnings.push(`Failed to create or update Submodel '${submodelId}'.`)
       }
     }
 
-    const importedAasIds: string[] = []
-    for (const { core: aas, json } of parsedPackage.aasById.values()) {
-      const success = await upsertAas(aas)
-      if (success) {
-        importedAasIds.push(asString(json.id))
-      } else {
-        warnings.push(`Failed to create or update AAS '${asString(json.id)}'.`)
-      }
+    if (!useSuperpath) {
+      await upsertParsedAasEntries()
     }
 
     for (const attachment of parsedPackage.attachments) {
-      const smEndpoint = getSmEndpointById(attachment.submodelId)
+      const aasId = useSuperpath ? findAasIdForSubmodel(parsedPackage, attachment.submodelId) : undefined
+      const smEndpoint = getSmEndpointById(attachment.submodelId, aasId)
       if (!smEndpoint || smEndpoint.trim() === '') {
         warnings.push(
           `Skipped attachment upload: no Submodel endpoint available for '${attachment.submodelId}'.`,

--- a/aas-web-ui/src/composables/AAS/AASXImport.ts
+++ b/aas-web-ui/src/composables/AAS/AASXImport.ts
@@ -7,7 +7,7 @@ import { useAASRepositoryClient } from '@/composables/Client/AASRepositoryClient
 import { useCDRepositoryClient } from '@/composables/Client/CDRepositoryClient'
 import { useSMRepositoryClient } from '@/composables/Client/SMRepositoryClient'
 import { useInfrastructureStore } from '@/store/InfrastructureStore'
-import { usesSubmodelSuperpath } from '@/utils/InfrastructureUtils'
+import { isComponentActiveForTemplate, usesSubmodelSuperpath } from '@/utils/InfrastructureUtils'
 import { safeSegment } from '@/utils/StringUtils'
 
 type JsonRecord = Record<string, unknown>
@@ -579,7 +579,12 @@ export function useAASXImport (): {
   }
 
   async function importParsedPackage (parsedPackage: ParsedAASX, warnings: string[]): Promise<ClientAASXImportResult> {
-    const useSuperpath = usesSubmodelSuperpath(infrastructureStore.getSelectedInfrastructure)
+    const selectedInfrastructure = infrastructureStore.getSelectedInfrastructure
+    const useSuperpath = usesSubmodelSuperpath(selectedInfrastructure)
+    const conceptDescriptionRepoActive = isComponentActiveForTemplate(
+      selectedInfrastructure,
+      'ConceptDescriptionRepo',
+    )
     const importedAasIds: string[] = []
 
     async function upsertParsedAasEntries (): Promise<void> {
@@ -593,10 +598,12 @@ export function useAASXImport (): {
       }
     }
 
-    for (const { core: conceptDescription, json } of parsedPackage.cdById.values()) {
-      const success = await upsertConceptDescription(conceptDescription)
-      if (!success) {
-        warnings.push(`Failed to create or update Concept Description '${asString(json.id)}'.`)
+    if (conceptDescriptionRepoActive) {
+      for (const { core: conceptDescription, json } of parsedPackage.cdById.values()) {
+        const success = await upsertConceptDescription(conceptDescription)
+        if (!success) {
+          warnings.push(`Failed to create or update Concept Description '${asString(json.id)}'.`)
+        }
       }
     }
 

--- a/aas-web-ui/src/composables/AAS/SMHandling.ts
+++ b/aas-web-ui/src/composables/AAS/SMHandling.ts
@@ -195,6 +195,7 @@ export function useSMHandling () {
     smId: string,
     withConceptDescriptions = false,
     setDataFlag = false,
+    aasId?: string,
   ): Promise<any> {
     const failResponse = {}
 
@@ -208,7 +209,7 @@ export function useSMHandling () {
       return failResponse
     }
 
-    const smEndpoint = await getSmEndpointById(smId)
+    const smEndpoint = await getSmEndpointById(smId, aasId)
 
     return smEndpoint && smEndpoint.trim() !== ''
       ? fetchSm(smEndpoint.trim(), withConceptDescriptions, setDataFlag)
@@ -222,7 +223,7 @@ export function useSMHandling () {
    * @param {string} smId - The ID of the Submodel to delete.
    * @returns {Promise<boolean>} A promise that resolves to a boolean indicating success.
    */
-  async function deleteSmById (smId: string): Promise<boolean> {
+  async function deleteSmById (smId: string, aasId?: string): Promise<boolean> {
     const failResponse = false
 
     if (!smId) {
@@ -235,7 +236,7 @@ export function useSMHandling () {
       return failResponse
     }
 
-    const smEndpoint = await getSmEndpointById(smId)
+    const smEndpoint = await getSmEndpointById(smId, aasId)
     if (smEndpoint && smEndpoint.trim() !== '') {
       return await deleteSm(smEndpoint.trim())
     }
@@ -277,7 +278,7 @@ export function useSMHandling () {
    * @param {string} smId - The ID of the SM to retrieve the endpoint for.
    * @returns {Promise<string>} A promise that resolves to an SM endpoint.
    */
-  async function getSmEndpointById (smId: string): Promise<string> {
+  async function getSmEndpointById (smId: string, aasId?: string): Promise<string> {
     const failResponse = ''
 
     if (!smId) {
@@ -298,7 +299,7 @@ export function useSMHandling () {
     }
 
     // Second try to determine SM endpoint with the help of the repo
-    smEndpoint = getSmEndpointByIdFromRepo(smId)
+    smEndpoint = getSmEndpointByIdFromRepo(smId, aasId)
 
     return smEndpoint.trim() || failResponse
   }

--- a/aas-web-ui/src/composables/Client/SMRepositoryClient.ts
+++ b/aas-web-ui/src/composables/Client/SMRepositoryClient.ts
@@ -3,13 +3,16 @@ import { jsonization } from '@aas-core-works/aas-core3.1-typescript'
 import { computed } from 'vue'
 import { useIDUtils } from '@/composables/IDUtils'
 import { useRequestHandling } from '@/composables/RequestHandling'
+import { useAASStore } from '@/store/AASDataStore'
 import { useInfrastructureStore } from '@/store/InfrastructureStore'
 import { base64Encode } from '@/utils/EncodeDecodeUtils'
+import { usesSubmodelSuperpath } from '@/utils/InfrastructureUtils'
 import { stripLastCharacter } from '@/utils/StringUtils'
 
 export function useSMRepositoryClient () {
   // Stores
   const infrastructureStore = useInfrastructureStore()
+  const aasStore = useAASStore()
 
   // Composables
   const {
@@ -23,6 +26,7 @@ export function useSMRepositoryClient () {
   const { generateUUIDFromString } = useIDUtils()
 
   const endpointPath = '/submodels'
+  const aasEndpointPath = '/shells'
 
   function ensureWriteSuccess (response: any): boolean {
     return response?.success === true
@@ -30,6 +34,81 @@ export function useSMRepositoryClient () {
 
   // Computed Properties
   const submodelRepoUrl = computed(() => infrastructureStore.getSubmodelRepoURL)
+  const aasRepositoryUrl = computed(() => infrastructureStore.getAASRepoURL)
+  const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
+
+  function shouldUseAasSuperpath (): boolean {
+    return usesSubmodelSuperpath(selectedInfrastructure.value)
+  }
+
+  function getAasEndpointById (aasId: string): string {
+    const failResponse = ''
+
+    if (!aasId) {
+      return failResponse
+    }
+
+    aasId = aasId.trim()
+
+    if (aasId === '') {
+      return failResponse
+    }
+
+    let aasRepoUrl = aasRepositoryUrl.value.trim()
+    if (aasRepoUrl === '') {
+      return failResponse
+    }
+    if (aasRepoUrl.endsWith('/')) {
+      aasRepoUrl = stripLastCharacter(aasRepoUrl)
+    }
+    if (!aasRepoUrl.endsWith(aasEndpointPath)) {
+      aasRepoUrl += aasEndpointPath
+    }
+
+    return aasRepoUrl + '/' + base64Encode(aasId)
+  }
+
+  function getAasEndpointForSubmodel (aasId?: string): string {
+    const selectedAas = aasStore.getSelectedAAS
+    const selectedAasId = typeof selectedAas?.id === 'string' ? selectedAas.id.trim() : ''
+    const effectiveAasId = aasId?.trim() || selectedAasId
+
+    if (effectiveAasId === '') {
+      return ''
+    }
+
+    if (
+      selectedAasId === effectiveAasId
+      && typeof selectedAas?.path === 'string'
+      && selectedAas.path.trim() !== ''
+    ) {
+      return selectedAas.path.trim()
+    }
+
+    return getAasEndpointById(effectiveAasId)
+  }
+
+  function getSuperpathSmEndpointById (smId: string, aasId?: string): string {
+    const failResponse = ''
+
+    if (!smId) {
+      return failResponse
+    }
+
+    smId = smId.trim()
+
+    if (smId === '') {
+      return failResponse
+    }
+
+    const aasEndpoint = getAasEndpointForSubmodel(aasId)
+    if (aasEndpoint === '') {
+      return failResponse
+    }
+
+    const normalizedAasEndpoint = aasEndpoint.endsWith('/') ? stripLastCharacter(aasEndpoint) : aasEndpoint
+    return normalizedAasEndpoint + endpointPath + '/' + base64Encode(smId)
+  }
 
   /**
    * Fetches a list of all available Submodels (SMs).
@@ -75,7 +154,7 @@ export function useSMRepositoryClient () {
    * @param {string} smId - The ID of the SM to fetch.
    * @returns {Promise<any>} A promise that resolves to a SM.
    */
-  async function fetchSmById (smId: string): Promise<any> {
+  async function fetchSmById (smId: string, aasId?: string): Promise<any> {
     const failResponse = {} as any
 
     if (!smId) {
@@ -88,7 +167,7 @@ export function useSMRepositoryClient () {
       return failResponse
     }
 
-    const smEndpoint = getSmEndpointById(smId)
+    const smEndpoint = getSmEndpointById(smId, aasId)
 
     if (smEndpoint && smEndpoint.trim() !== '') {
       return fetchSm(smEndpoint.trim())
@@ -351,7 +430,7 @@ export function useSMRepositoryClient () {
    * @param {string} smId - The ID of the SM to retrieve the endpoint for.
    * @returns {string} The SM endpoint.
    */
-  function getSmEndpointById (smId: string): string {
+  function getSmEndpointById (smId: string, aasId?: string): string {
     const failResponse = ''
 
     if (!smId) {
@@ -362,6 +441,10 @@ export function useSMRepositoryClient () {
 
     if (smId === '') {
       return failResponse
+    }
+
+    if (shouldUseAasSuperpath()) {
+      return getSuperpathSmEndpointById(smId, aasId)
     }
 
     let smRepoUrl = submodelRepoUrl.value.trim()
@@ -380,8 +463,29 @@ export function useSMRepositoryClient () {
     return smEndpoint || failResponse
   }
 
-  async function postSubmodel (submodel: aasTypes.Submodel, suppressRequestErrorMessage = false): Promise<boolean> {
+  async function postSubmodel (
+    submodel: aasTypes.Submodel,
+    suppressRequestErrorMessage = false,
+    aasId?: string,
+  ): Promise<boolean> {
     const failResponse = false
+
+    if (shouldUseAasSuperpath()) {
+      const path = getSuperpathSmEndpointById(submodel.id, aasId)
+      if (path === '') {
+        return failResponse
+      }
+
+      const jsonSubmodel = jsonization.toJsonable(submodel)
+      const context = 'creating Submodel via AAS superpath'
+      const disableMessage = suppressRequestErrorMessage
+      const headers = new Headers()
+      headers.append('Content-Type', 'application/json')
+      const body = JSON.stringify(jsonSubmodel)
+
+      const response = await putRequest(path, body, headers, context, disableMessage)
+      return response.success
+    }
 
     let smRepoUrl = submodelRepoUrl.value.trim()
     if (smRepoUrl === '') {
@@ -409,8 +513,29 @@ export function useSMRepositoryClient () {
     return response.success
   }
 
-  async function putSubmodel (submodel: aasTypes.Submodel, suppressRequestErrorMessage = false): Promise<boolean> {
+  async function putSubmodel (
+    submodel: aasTypes.Submodel,
+    suppressRequestErrorMessage = false,
+    aasId?: string,
+  ): Promise<boolean> {
     const failResponse = false
+
+    if (shouldUseAasSuperpath()) {
+      const path = getSuperpathSmEndpointById(submodel.id, aasId)
+      if (path === '') {
+        return failResponse
+      }
+
+      const jsonSubmodel = jsonization.toJsonable(submodel)
+      const context = 'updating Submodel via AAS superpath'
+      const disableMessage = suppressRequestErrorMessage
+      const headers = new Headers()
+      headers.append('Content-Type', 'application/json')
+      const body = JSON.stringify(jsonSubmodel)
+
+      const response = await putRequest(path, body, headers, context, disableMessage)
+      return response.success
+    }
 
     let smRepoUrl = submodelRepoUrl.value.trim()
     if (smRepoUrl === '') {
@@ -445,7 +570,7 @@ export function useSMRepositoryClient () {
    * @param {string} submodelId - The ID of the Submodel to delete.
    * @returns {Promise<boolean>} A promise that resolves to a boolean indicating success.
    */
-  async function deleteSubmodelById (submodelId: string): Promise<boolean> {
+  async function deleteSubmodelById (submodelId: string, aasId?: string): Promise<boolean> {
     const failResponse = false
 
     if (!submodelId) {
@@ -458,7 +583,7 @@ export function useSMRepositoryClient () {
       return failResponse
     }
 
-    const smEndpoint = getSmEndpointById(submodelId)
+    const smEndpoint = getSmEndpointById(submodelId, aasId)
 
     if (smEndpoint && smEndpoint.trim() !== '') {
       const path = smEndpoint
@@ -503,8 +628,27 @@ export function useSMRepositoryClient () {
     submodelId: string,
     idShortPath?: string,
     suppressRequestErrorMessage = false,
+    aasId?: string,
   ): Promise<boolean> {
     const failResponse = false
+
+    if (shouldUseAasSuperpath()) {
+      const smEndpoint = getSuperpathSmEndpointById(submodelId, aasId)
+      if (smEndpoint === '') {
+        return failResponse
+      }
+
+      const jsonSubmodelElement = jsonization.toJsonable(submodelElement)
+      const context = 'creating Submodel Element via AAS superpath'
+      const disableMessage = suppressRequestErrorMessage
+      const path = smEndpoint + '/submodel-elements' + (idShortPath ? '/' + idShortPath : '')
+      const headers = new Headers()
+      headers.append('Content-Type', 'application/json')
+      const body = JSON.stringify(jsonSubmodelElement)
+
+      const response = await postRequest(path, body, headers, context, disableMessage)
+      return ensureWriteSuccess(response)
+    }
 
     let smRepoUrl = submodelRepoUrl.value.trim()
     if (smRepoUrl === '') {

--- a/aas-web-ui/src/composables/ClipboardUtil.ts
+++ b/aas-web-ui/src/composables/ClipboardUtil.ts
@@ -6,10 +6,9 @@ import { useSMRepositoryClient } from '@/composables/Client/SMRepositoryClient'
 import { useIDUtils } from '@/composables/IDUtils'
 import { useAASStore } from '@/store/AASDataStore'
 import { useClipboardStore } from '@/store/ClipboardStore'
-import { useInfrastructureStore } from '@/store/InfrastructureStore'
 import { useNavigationStore } from '@/store/NavigationStore'
 import { getCreatedSubmodelElementPath, isDataElementModelType } from '@/utils/AAS/SubmodelElementPathUtils'
-import { base64Decode, base64Encode } from '@/utils/EncodeDecodeUtils'
+import { base64Decode } from '@/utils/EncodeDecodeUtils'
 
 export function useClipboardUtil () {
   // Vue Router
@@ -20,16 +19,14 @@ export function useClipboardUtil () {
   const aasStore = useAASStore()
   const clipboardStore = useClipboardStore()
   const navigationStore = useNavigationStore()
-  const infrastructureStore = useInfrastructureStore()
 
   // composables
-  const { postSubmodel, postSubmodelElement } = useSMRepositoryClient()
+  const { postSubmodel, postSubmodelElement, getSmEndpointById } = useSMRepositoryClient()
   const { putAas } = useAASRepositoryClient()
   const { generateIri } = useIDUtils()
 
   // Computed properties
   const selectedAAS = computed(() => aasStore.getSelectedAAS)
-  const submodelRepoUrl = computed(() => infrastructureStore.getSubmodelRepoURL)
 
   function copyToClipboard (value: string, valueName: string, iconReference: { value: string }): void {
     if (!value) {
@@ -147,7 +144,7 @@ export function useClipboardUtil () {
     await addSubmodelReferenceToAas(submodel)
     // Fetch and dispatch Submodel
     const query = structuredClone(route.query)
-    query.path = submodelRepoUrl.value + '/' + base64Encode(submodel.id)
+    query.path = getSmEndpointById(submodel.id)
     router.push({ query })
 
     navigationStore.dispatchTriggerTreeviewReload()

--- a/aas-web-ui/src/composables/Infrastructure/useComponentConnectionTesting.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useComponentConnectionTesting.ts
@@ -1,8 +1,19 @@
 import type { BaSyxComponentKey } from '@/types/BaSyx'
-import type { ComponentConnectionStatus, ComponentTestingLoading } from '@/types/Infrastructure'
+import type {
+  ComponentConnectionStatus,
+  ComponentTestingLoading,
+  InfrastructureConfig,
+  InfrastructureTemplate,
+} from '@/types/Infrastructure'
+import type { InfrastructureEndpointFieldKey } from '@/utils/InfrastructureUtils'
 import { type Ref, ref } from 'vue'
 import { useInfrastructureStore } from '@/store/InfrastructureStore'
-import { BASYX_COMPONENT_KEYS } from '@/utils/InfrastructureUtils'
+import {
+  BASYX_COMPONENT_KEYS,
+  getEndpointFieldByKey,
+  getEndpointFieldsForTemplate,
+  getEndpointFieldValue,
+} from '@/utils/InfrastructureUtils'
 
 /**
  * Composable for managing BaSyx component connection testing
@@ -12,7 +23,15 @@ export function useComponentConnectionTesting (): {
   componentTestingLoading: Ref<ComponentTestingLoading>
   testingAllConnections: Ref<boolean>
   testComponentConnection: (componentKey: BaSyxComponentKey, url: string) => Promise<void>
-  testAllConnections: (components: Record<BaSyxComponentKey, { url: string }>) => Promise<void>
+  testEndpointField: (
+    template: InfrastructureTemplate,
+    fieldKey: InfrastructureEndpointFieldKey,
+    components: InfrastructureConfig['components'],
+  ) => Promise<void>
+  testAllConnections: (
+    components: InfrastructureConfig['components'],
+    template: InfrastructureTemplate,
+  ) => Promise<void>
   resetConnectionStatus: () => void
 } {
   const infrastructureStore = useInfrastructureStore()
@@ -58,11 +77,36 @@ export function useComponentConnectionTesting (): {
   }
 
   /**
+   * Test connection to a visible endpoint field. Grouped endpoint fields fan out to
+   * their mapped internal components.
+   */
+  async function testEndpointField (
+    template: InfrastructureTemplate,
+    fieldKey: InfrastructureEndpointFieldKey,
+    components: InfrastructureConfig['components'],
+  ): Promise<void> {
+    const endpointField = getEndpointFieldByKey(template, fieldKey)
+    if (!endpointField) {
+      return
+    }
+
+    const url = getEndpointFieldValue(components, endpointField)
+    const testPromises = endpointField.componentKeys.map(key => testComponentConnection(key, url))
+    await Promise.all(testPromises)
+  }
+
+  /**
    * Test all component connections
    */
-  async function testAllConnections (components: Record<BaSyxComponentKey, { url: string }>): Promise<void> {
+  async function testAllConnections (
+    components: InfrastructureConfig['components'],
+    template: InfrastructureTemplate,
+  ): Promise<void> {
     testingAllConnections.value = true
-    const testPromises = BASYX_COMPONENT_KEYS.map(key => testComponentConnection(key, components[key].url))
+    const testPromises = getEndpointFieldsForTemplate(template).flatMap(endpointField => {
+      const url = getEndpointFieldValue(components, endpointField)
+      return endpointField.componentKeys.map(key => testComponentConnection(key, url))
+    })
     await Promise.all(testPromises)
     testingAllConnections.value = false
   }
@@ -84,6 +128,7 @@ export function useComponentConnectionTesting (): {
     testingAllConnections,
     // Methods
     testComponentConnection,
+    testEndpointField,
     testAllConnections,
     resetConnectionStatus,
   }

--- a/aas-web-ui/src/composables/Infrastructure/useComponentConnectionTesting.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useComponentConnectionTesting.ts
@@ -41,22 +41,31 @@ export function useComponentConnectionTesting (): {
   const componentTestingLoading = ref<ComponentTestingLoading>({} as ComponentTestingLoading)
   const testingAllConnections = ref(false)
 
+  function updateGlobalTestingState (): void {
+    infrastructureStore.dispatchIsTestingConnections(Object.values(componentTestingLoading.value).some(Boolean))
+  }
+
+  function setComponentTestingLoading (componentKey: BaSyxComponentKey, loading: boolean): void {
+    componentTestingLoading.value[componentKey] = loading
+    updateGlobalTestingState()
+  }
+
   /**
    * Test connection to a single component
    */
   async function testComponentConnection (componentKey: BaSyxComponentKey, url: string): Promise<void> {
     if (!url || url.trim() === '') {
       componentConnectionStatus.value[componentKey] = false
+      setComponentTestingLoading(componentKey, false)
       return
     }
 
-    componentTestingLoading.value[componentKey] = true
     componentConnectionStatus.value[componentKey] = null
+    const originalUrl = infrastructureStore.getBasyxComponents[componentKey].url
+    setComponentTestingLoading(componentKey, true)
 
     try {
       // Temporarily set the component URL in the store to test it
-      const originalUrl = infrastructureStore.getBasyxComponents[componentKey].url
-      infrastructureStore.dispatchIsTestingConnections(true)
       infrastructureStore.getBasyxComponents[componentKey].url = url
 
       // Test the connection
@@ -65,14 +74,12 @@ export function useComponentConnectionTesting (): {
       // Get the connection result
       const connected = infrastructureStore.getBasyxComponents[componentKey].connected
       componentConnectionStatus.value[componentKey] = connected
-
-      // Restore original URL
-      infrastructureStore.getBasyxComponents[componentKey].url = originalUrl
     } catch {
       componentConnectionStatus.value[componentKey] = false
     } finally {
-      infrastructureStore.dispatchIsTestingConnections(false)
-      componentTestingLoading.value[componentKey] = false
+      // Restore original URL
+      infrastructureStore.getBasyxComponents[componentKey].url = originalUrl
+      setComponentTestingLoading(componentKey, false)
     }
   }
 
@@ -103,12 +110,15 @@ export function useComponentConnectionTesting (): {
     template: InfrastructureTemplate,
   ): Promise<void> {
     testingAllConnections.value = true
-    const testPromises = getEndpointFieldsForTemplate(template).flatMap(endpointField => {
-      const url = getEndpointFieldValue(components, endpointField)
-      return endpointField.componentKeys.map(key => testComponentConnection(key, url))
-    })
-    await Promise.all(testPromises)
-    testingAllConnections.value = false
+    try {
+      const testPromises = getEndpointFieldsForTemplate(template).flatMap(endpointField => {
+        const url = getEndpointFieldValue(components, endpointField)
+        return endpointField.componentKeys.map(key => testComponentConnection(key, url))
+      })
+      await Promise.all(testPromises)
+    } finally {
+      testingAllConnections.value = false
+    }
   }
 
   /**
@@ -119,6 +129,7 @@ export function useComponentConnectionTesting (): {
       componentConnectionStatus.value[key] = null
       componentTestingLoading.value[key] = false
     }
+    updateGlobalTestingState()
   }
 
   return {

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
@@ -1,7 +1,14 @@
-import type { InfrastructureConfig, InfrastructureStorage, OAuth2ConnectionData } from '@/types/Infrastructure'
+import type {
+  ComponentConfig,
+  InfrastructureConfig,
+  InfrastructureStorage,
+  InfrastructureTemplate,
+  OAuth2ConnectionData,
+} from '@/types/Infrastructure'
 import { authenticateOAuth2ClientCredentials } from '@/composables/Auth/OAuth2Auth'
 import { useInfrastructureConfigLoader } from '@/composables/Infrastructure/useInfrastructureConfigLoader'
 import { useNavigationStore } from '@/store/NavigationStore'
+import { normalizeInfrastructureTemplate } from '@/utils/InfrastructureUtils'
 
 /**
  * Computes a simple hash of infrastructure configuration for change detection
@@ -11,6 +18,7 @@ function computeInfrastructureHash (infra: InfrastructureConfig): string {
   // Create stable string representation of configuration (excluding runtime fields)
   const configForHashing = {
     name: infra.name,
+    template: normalizeInfrastructureTemplate(infra.template),
     components: infra.components,
     auth: infra.auth,
     // Exclude: id (stable), token (runtime), isDefault (user preference), yamlConfigOutdated (runtime flag)
@@ -31,7 +39,7 @@ function computeInfrastructureHash (infra: InfrastructureConfig): string {
  */
 export function useInfrastructureStorage (): {
   generateInfrastructureId: () => string
-  createEmptyInfrastructure: (name?: string) => InfrastructureConfig
+  createEmptyInfrastructure: (name?: string, template?: InfrastructureTemplate) => InfrastructureConfig
   createDefaultInfrastructureFromEnv: (
     envConfig: {
       aasDiscoveryPath?: string
@@ -133,6 +141,55 @@ export function useInfrastructureStorage (): {
     return 'infra_env_' + Math.abs(hash).toString(36)
   }
 
+  function createDefaultComponents (): Record<keyof InfrastructureConfig['components'], ComponentConfig> {
+    return {
+      AASDiscovery: {
+        url: '',
+      },
+      AASRegistry: {
+        url: '',
+        hasDiscoveryIntegration: true,
+      },
+      SubmodelRegistry: {
+        url: '',
+      },
+      AASRepo: {
+        url: '',
+        hasRegistryIntegration: true,
+      },
+      SubmodelRepo: {
+        url: '',
+        hasRegistryIntegration: true,
+      },
+      ConceptDescriptionRepo: {
+        url: '',
+      },
+    }
+  }
+
+  function normalizeInfrastructureConfig (infrastructure: InfrastructureConfig): InfrastructureConfig {
+    const normalized = infrastructure
+    normalized.template = normalizeInfrastructureTemplate(normalized.template)
+    normalized.auth ??= { securityType: 'No Authentication' }
+
+    const defaultComponents = createDefaultComponents()
+    const existingComponents = (normalized as Partial<InfrastructureConfig>).components
+    normalized.components = {
+      ...defaultComponents,
+      ...existingComponents,
+    }
+
+    for (const [key, defaultComponent] of Object.entries(defaultComponents)) {
+      const componentKey = key as keyof InfrastructureConfig['components']
+      normalized.components[componentKey] = {
+        ...defaultComponent,
+        ...normalized.components[componentKey],
+      }
+    }
+
+    return normalized
+  }
+
   /**
    * Authenticates using OAuth2 client credentials flow and updates infrastructure token
    */
@@ -157,34 +214,16 @@ export function useInfrastructureStorage (): {
   /**
    * Creates an empty infrastructure configuration with default values
    */
-  function createEmptyInfrastructure (name = 'New Infrastructure'): InfrastructureConfig {
+  function createEmptyInfrastructure (
+    name = 'New Infrastructure',
+    template: InfrastructureTemplate = 'full',
+  ): InfrastructureConfig {
     return {
       id: generateInfrastructureId(),
       name,
+      template,
       auth: { securityType: 'No Authentication' },
-      components: {
-        AASDiscovery: {
-          url: '',
-        },
-        AASRegistry: {
-          url: '',
-          hasDiscoveryIntegration: true,
-        },
-        SubmodelRegistry: {
-          url: '',
-        },
-        AASRepo: {
-          url: '',
-          hasRegistryIntegration: true,
-        },
-        SubmodelRepo: {
-          url: '',
-          hasRegistryIntegration: true,
-        },
-        ConceptDescriptionRepo: {
-          url: '',
-        },
-      },
+      components: createDefaultComponents(),
     }
   }
 
@@ -332,7 +371,7 @@ export function useInfrastructureStorage (): {
       infrastructure.components.ConceptDescriptionRepo.url = legacyConceptDescriptionRepoURL
     }
 
-    return infrastructure
+    return normalizeInfrastructureConfig(infrastructure)
   }
 
   type MatchingEnvConfig = {
@@ -437,6 +476,7 @@ export function useInfrastructureStorage (): {
     refreshTokensCallback?: (infrastructureId: string) => Promise<void>,
   ): Promise<void> {
     for (const infra of infrastructures) {
+      normalizeInfrastructureConfig(infra)
       if (
         infra.auth?.securityType === 'OAuth2'
         && infra.auth.oauth2?.authFlow === 'client-credentials'
@@ -473,8 +513,10 @@ export function useInfrastructureStorage (): {
     if (stored) {
       try {
         const storage: InfrastructureStorage = JSON.parse(stored)
+        storage.infrastructures = storage.infrastructures.map(infra => normalizeInfrastructureConfig(infra))
 
         for (const yamlInfra of yamlConfig.infrastructures) {
+          normalizeInfrastructureConfig(yamlInfra)
           const storedInfra = storage.infrastructures.find(infra => infra.id === yamlInfra.id)
           if (storedInfra) {
             if (storedInfra.token) {
@@ -532,8 +574,10 @@ export function useInfrastructureStorage (): {
     if (stored) {
       try {
         const storage: InfrastructureStorage = JSON.parse(stored)
+        storage.infrastructures = storage.infrastructures.map(infra => normalizeInfrastructureConfig(infra))
 
         for (const yamlInfra of yamlConfig.infrastructures) {
+          normalizeInfrastructureConfig(yamlInfra)
           const storedInfra = storage.infrastructures.find(infra => infra.id === yamlInfra.id)
           if (storedInfra) {
             const currentYamlHash = computeInfrastructureHash(yamlInfra)
@@ -571,11 +615,11 @@ export function useInfrastructureStorage (): {
           : fallbackSelectedId
       } catch (error) {
         console.warn('Failed to parse localStorage, using YAML config only:', error)
-        mergedInfrastructures.push(...yamlConfig.infrastructures)
+        mergedInfrastructures.push(...yamlConfig.infrastructures.map(infra => normalizeInfrastructureConfig(infra)))
         selectedId = fallbackSelectedId
       }
     } else {
-      mergedInfrastructures.push(...yamlConfig.infrastructures)
+      mergedInfrastructures.push(...yamlConfig.infrastructures.map(infra => normalizeInfrastructureConfig(infra)))
     }
 
     await authenticateClientCredentialsInfrastructures(mergedInfrastructures, refreshTokensCallback)
@@ -641,6 +685,7 @@ export function useInfrastructureStorage (): {
       if (stored) {
         try {
           const storage: InfrastructureStorage = JSON.parse(stored)
+          storage.infrastructures = storage.infrastructures.map(infra => normalizeInfrastructureConfig(infra))
           matchingInfra = findMatchingInfrastructure(storage.infrastructures, envConfig)
         } catch (error) {
           console.warn('Failed to load infrastructure from storage:', error)
@@ -671,6 +716,7 @@ export function useInfrastructureStorage (): {
     const stored = window.localStorage.getItem('basyxInfrastructures')
     if (stored) {
       const storage: InfrastructureStorage = JSON.parse(stored)
+      storage.infrastructures = storage.infrastructures.map(infra => normalizeInfrastructureConfig(infra))
 
       // Determine which infrastructure should be selected
       let targetInfraId: string | null = null
@@ -698,6 +744,7 @@ export function useInfrastructureStorage (): {
     } else {
       // Migration from legacy storage
       const legacyInfra = createInfrastructureFromLegacyStorage()
+      normalizeInfrastructureConfig(legacyInfra)
 
       // Check if any legacy URLs exist
       const hasLegacyData = Object.values(legacyInfra.components).some(comp => comp.url.trim() !== '')
@@ -802,7 +849,7 @@ export function useInfrastructureStorage (): {
   ): void {
     try {
       const storage: InfrastructureStorage = {
-        infrastructures,
+        infrastructures: infrastructures.map(infra => normalizeInfrastructureConfig(infra)),
         selectedInfrastructureId,
       }
 

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureYamlParser.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureYamlParser.ts
@@ -3,10 +3,15 @@ import type {
   InfrastructureAuth,
   InfrastructureConfig,
   ParsedInfrastructureConfig,
+  YamlComponentConfig,
   YamlInfrastructureConfig,
   YamlInfrastructuresConfig,
   YamlSecurityConfig,
 } from '@/types/Infrastructure'
+import {
+  getEndpointFieldsForTemplate,
+  normalizeInfrastructureTemplate,
+} from '@/utils/InfrastructureUtils'
 
 /**
  * Composable for parsing YAML infrastructure configuration
@@ -146,9 +151,11 @@ export function useInfrastructureYamlParser (): {
     yamlConfig: YamlInfrastructureConfig,
     isDefault = false,
   ): InfrastructureConfig {
+    const template = normalizeInfrastructureTemplate(yamlConfig.template)
     const infrastructure: InfrastructureConfig = {
       id: generateYamlInfrastructureId(yamlKey),
       name: yamlConfig.name || yamlKey,
+      template,
       isDefault,
       auth: parseSecurityConfig(yamlConfig.security),
       components: {
@@ -161,20 +168,44 @@ export function useInfrastructureYamlParser (): {
       },
     }
 
-    // Map YAML component configurations to internal structure
-    for (const [yamlKey, internalKey] of Object.entries(componentKeyMap)) {
-      const yamlComponent = yamlConfig.components[yamlKey as keyof typeof yamlConfig.components]
-      if (yamlComponent?.baseUrl) {
-        infrastructure.components[internalKey].url = yamlComponent.baseUrl
-        if (yamlComponent.hasRegistryIntegration !== undefined) {
-          infrastructure.components[internalKey].hasRegistryIntegration
+    function applyYamlComponentToKeys (
+      yamlComponent: YamlComponentConfig | undefined,
+      componentKeys: BaSyxComponentKey[],
+    ): void {
+      if (!yamlComponent?.baseUrl) {
+        return
+      }
+
+      for (const componentKey of componentKeys) {
+        infrastructure.components[componentKey].url = yamlComponent.baseUrl
+
+        if (
+          yamlComponent.hasRegistryIntegration !== undefined
+          && (componentKey === 'AASRepo' || componentKey === 'SubmodelRepo')
+        ) {
+          infrastructure.components[componentKey].hasRegistryIntegration
             = yamlComponent.hasRegistryIntegration
         }
-        if (yamlComponent.hasDiscoveryIntegration !== undefined) {
-          infrastructure.components[internalKey].hasDiscoveryIntegration
+
+        if (yamlComponent.hasDiscoveryIntegration !== undefined && componentKey === 'AASRegistry') {
+          infrastructure.components[componentKey].hasDiscoveryIntegration
             = yamlComponent.hasDiscoveryIntegration
         }
       }
+    }
+
+    // Map YAML component configurations to internal structure
+    for (const [yamlKey, internalKey] of Object.entries(componentKeyMap)) {
+      const yamlComponent = yamlConfig.components[yamlKey as keyof typeof yamlConfig.components]
+      applyYamlComponentToKeys(yamlComponent, [internalKey])
+    }
+
+    // Map grouped endpoint configurations for templates such as mono-repo and Catena-X.
+    for (const endpointField of getEndpointFieldsForTemplate(template)) {
+      const yamlComponent = yamlConfig.components[
+        endpointField.yamlKey as keyof typeof yamlConfig.components
+      ]
+      applyYamlComponentToKeys(yamlComponent, endpointField.componentKeys)
     }
 
     return infrastructure

--- a/aas-web-ui/src/composables/ModuleHandling.ts
+++ b/aas-web-ui/src/composables/ModuleHandling.ts
@@ -2,7 +2,9 @@ import type { ModuleNavigationRoute } from '@/types/Application'
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
 import { useAASStore } from '@/store/AASDataStore'
+import { useInfrastructureStore } from '@/store/InfrastructureStore'
 import { useNavigationStore } from '@/store/NavigationStore'
+import { supportsInfrastructureTemplate } from '@/utils/InfrastructureUtils'
 
 interface ModuleHandling {
   determineFilteredAndOrderedModuleRoutes: () => ModuleNavigationRoute[]
@@ -16,12 +18,14 @@ export function useModuleHandling (): ModuleHandling {
   // Stores
   const navigationStore = useNavigationStore()
   const aasStore = useAASStore()
+  const infrastructureStore = useInfrastructureStore()
 
   // Computed Properties
   const isMobile = computed(() => navigationStore.getIsMobile)
   const moduleRoutes = computed(() => navigationStore.getModuleRoutes) // get the module routes
   const selectedAas = computed(() => aasStore.getSelectedAAS) // get selected AAS from Store
   const selectedNode = computed(() => aasStore.getSelectedNode) // get selected node from Store
+  const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
 
   function determineFilteredAndOrderedModuleRoutes () {
     const currentRouteName = typeof route.name === 'string' ? route.name : undefined
@@ -31,6 +35,14 @@ export function useModuleHandling (): ModuleHandling {
           return false
         }
         if (!isMobile.value && !moduleRoute?.meta?.isDesktopModule) {
+          return false
+        }
+        if (
+          !supportsInfrastructureTemplate(
+            moduleRoute?.meta?.supportedInfrastructureTemplates,
+            selectedInfrastructure.value,
+          )
+        ) {
           return false
         }
         if (

--- a/aas-web-ui/src/pages/modules/AASCreationWizard/components/StepHandoverDocumentation.vue
+++ b/aas-web-ui/src/pages/modules/AASCreationWizard/components/StepHandoverDocumentation.vue
@@ -59,6 +59,7 @@
   import { jsonization } from '@aas-core-works/aas-core3.1-typescript'
   import { onMounted, ref } from 'vue'
   import { useRouter } from 'vue-router'
+  import { useSMRepositoryClient } from '@/composables/Client/SMRepositoryClient'
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { base64Encode } from '@/utils/EncodeDecodeUtils'
   import { buildHandoverDocumentation } from '../builders/buildHandoverDocumentation'
@@ -83,6 +84,7 @@
   const { submitAll } = useAASCreationSubmission()
   const infrastructureStore = useInfrastructureStore()
   const router = useRouter()
+  const { getSmEndpointById } = useSMRepositoryClient()
 
   const isSubmitting = ref(false)
 
@@ -243,7 +245,7 @@
   ): Promise<void> {
     const aasEndpoint = `${withTrailingSlash(infrastructureStore.getAASRepoURL)}shells/${base64Encode(aasId)}`
 
-    const submodelEndpoint = `${withTrailingSlash(infrastructureStore.getSubmodelRepoURL)}submodels/${base64Encode(submodelIdToOpen)}`
+    const submodelEndpoint = getSmEndpointById(submodelIdToOpen, aasId)
 
     await router.push({
       path: '/aassmviewer',

--- a/aas-web-ui/src/pages/modules/AASCreationWizard/composables/useAASCreationSubmission.ts
+++ b/aas-web-ui/src/pages/modules/AASCreationWizard/composables/useAASCreationSubmission.ts
@@ -6,6 +6,8 @@ import type {
   TemplateElement } from '../types/template'
 import { jsonization } from '@aas-core-works/aas-core3.1-typescript'
 import { useAASRepositoryClient } from '@/composables/Client/AASRepositoryClient'
+import { useInfrastructureStore } from '@/store/InfrastructureStore'
+import { usesSubmodelSuperpath } from '@/utils/InfrastructureUtils'
 import { buildAssetAdministrationShell } from '../builders/buildAssetAdministrationShell'
 import { useAASCreationStore } from '../stores/aasCreationForm'
 import digitalNameplateTemplate from '../templates/digital-nameplate.json'
@@ -57,10 +59,12 @@ function getSubmodelId (submodelData: unknown): string | null {
 export function useAASCreationSubmission () {
   const { postAas, putThumbnail } = useAASRepositoryClient()
   const { postSubmodel, getSmEndpointById, putAttachmentFile } = useSMRepositoryClient()
+  const infrastructureStore = useInfrastructureStore()
   const store = useAASCreationStore()
 
   async function postBuiltSubmodel (
     submodelData: unknown,
+    aasId?: string,
   ): Promise<boolean> {
     try {
       const submodelParseResult = jsonization.submodelFromJsonable(submodelData as any)
@@ -70,7 +74,7 @@ export function useAASCreationSubmission () {
       }
       const submodelInstance = submodelParseResult.mustValue()
 
-      const submodelSuccess = await postSubmodel(submodelInstance)
+      const submodelSuccess = await postSubmodel(submodelInstance, false, aasId)
 
       if (!submodelSuccess) {
         return false
@@ -78,6 +82,37 @@ export function useAASCreationSubmission () {
       return true
     } catch (error) {
       window.alert(`There was an error creating submodel: ${String(error)}`)
+      return false
+    }
+  }
+
+  async function postBuiltAas (
+    builtAas: ReturnType<typeof buildAssetAdministrationShell>,
+    thumbnailFile?: File | null,
+  ): Promise<boolean> {
+    try {
+      const aasParseResult = jsonization.assetAdministrationShellFromJsonable(builtAas as any)
+      if (aasParseResult.error !== null) {
+        return false
+      }
+      const aasInstance = aasParseResult.mustValue()
+
+      const success = await postAas(aasInstance)
+
+      if (!success) {
+        return false
+      }
+      if (thumbnailFile) {
+        const thumbnailSuccess = await putThumbnail(thumbnailFile, builtAas.id)
+
+        if (!thumbnailSuccess) {
+          return false
+        }
+      }
+
+      return true
+    } catch (error) {
+      window.alert(`There was an error creating aas: ${String(error)}`)
       return false
     }
   }
@@ -106,9 +141,21 @@ export function useAASCreationSubmission () {
       return { success: false }
     }
 
+    const builtAas = buildAssetAdministrationShell(assetData, digitalNameplate, technicalData, handoverDocumentation)
+    const useSuperpath = usesSubmodelSuperpath(infrastructureStore.getSelectedInfrastructure)
+    const aasIdForSubmodelSuperpath = useSuperpath ? builtAas.id : undefined
+
+    if (useSuperpath) {
+      const aasSuccess = await postBuiltAas(builtAas, assetData.thumbnailFile)
+      if (!aasSuccess) {
+        return { success: false }
+      }
+    }
+
     // build digital nameplate
     const digitalNameplateSuccess = await postBuiltSubmodel(
       digitalNameplate,
+      aasIdForSubmodelSuperpath,
     )
     if (!digitalNameplateSuccess) {
       return { success: false }
@@ -117,6 +164,7 @@ export function useAASCreationSubmission () {
       digitalNameplateId,
       digitalNameplateTemplateData.submodelElements,
       store.digitalNameplateFormState,
+      aasIdForSubmodelSuperpath,
     )
 
     if (!digitalNameplateFilesSuccess) {
@@ -125,6 +173,7 @@ export function useAASCreationSubmission () {
     // build technical data
     const technicalDataSuccess = await postBuiltSubmodel(
       technicalData,
+      aasIdForSubmodelSuperpath,
     )
     if (!technicalDataSuccess) {
       return { success: false }
@@ -134,6 +183,7 @@ export function useAASCreationSubmission () {
       technicalDataId,
       technicalDataTemplateData.submodelElements,
       store.technicalDataFormState,
+      aasIdForSubmodelSuperpath,
     )
 
     if (!technicalDataFilesSuccess) {
@@ -143,6 +193,7 @@ export function useAASCreationSubmission () {
     // build handover documentation
     const handoverDocumentationSuccess = await postBuiltSubmodel(
       handoverDocumentation,
+      aasIdForSubmodelSuperpath,
     )
     if (!handoverDocumentationSuccess) {
       return { success: false }
@@ -151,43 +202,24 @@ export function useAASCreationSubmission () {
       handoverDocumentationId,
       handoverDocumentationTemplateData.submodelElements,
       store.handoverDocumentationFormState,
+      aasIdForSubmodelSuperpath,
     )
 
     if (!handoverDocumentationFilesSuccess) {
       return { success: false }
     }
 
-    // post the aas with submodels
-    const builtAas = buildAssetAdministrationShell(assetData, digitalNameplate, technicalData, handoverDocumentation)
-
-    try {
-      const aasParseResult = jsonization.assetAdministrationShellFromJsonable(builtAas as any)
-      if (aasParseResult.error !== null) {
+    if (!useSuperpath) {
+      const aasSuccess = await postBuiltAas(builtAas, assetData.thumbnailFile)
+      if (!aasSuccess) {
         return { success: false }
       }
-      const aasInstance = aasParseResult.mustValue()
+    }
 
-      const success = await postAas(aasInstance)
-
-      if (!success) {
-        return { success: false }
-      }
-      if (assetData.thumbnailFile) {
-        const thumbnailSuccess = await putThumbnail(assetData.thumbnailFile, builtAas.id)
-
-        if (!thumbnailSuccess) {
-          return { success: false }
-        }
-      }
-
-      return {
-        success: true,
-        aasId: builtAas.id,
-        submodelIdToOpen: handoverDocumentationId,
-      }
-    } catch (error) {
-      window.alert(`There was an error creating aas: ${String(error)}`)
-      return { success: false }
+    return {
+      success: true,
+      aasId: builtAas.id,
+      submodelIdToOpen: handoverDocumentationId,
     }
   }
 
@@ -195,12 +227,13 @@ export function useAASCreationSubmission () {
     submodelId: string,
     elements: TemplateElement[],
     formState: FormStateObject | null,
+    aasId?: string,
   ): Promise<boolean> {
     const fileTasks = collectSubmodelFileUploadTasks(
       submodelId,
       elements,
       formState,
-      getSmEndpointById,
+      id => getSmEndpointById(id, aasId),
     )
 
     for (const task of fileTasks) {

--- a/aas-web-ui/src/pages/modules/AASCreationWizard/index.vue
+++ b/aas-web-ui/src/pages/modules/AASCreationWizard/index.vue
@@ -78,6 +78,7 @@
     moduleTitle: 'AAS Creation Wizard',
     isDesktopModule: true,
     isMobileModule: false,
+    supportedInfrastructureTemplates: ['full', 'identifiable', 'mono-repo', 'mono-all'],
   })
 
   const step = ref(1)

--- a/aas-web-ui/src/pages/modules/AasImporter.vue
+++ b/aas-web-ui/src/pages/modules/AasImporter.vue
@@ -203,6 +203,7 @@
   defineOptions({
     inheritAttrs: false,
     moduleTitle: 'AAS Importer',
+    supportedInfrastructureTemplates: ['full', 'identifiable', 'mono-repo', 'mono-all'],
   })
 
   const navigationStore = useNavigationStore()

--- a/aas-web-ui/src/pages/modules/AasImporter.vue
+++ b/aas-web-ui/src/pages/modules/AasImporter.vue
@@ -58,6 +58,7 @@
           v-model="sourceUseSuperpath"
           class="mt-n2 mb-2"
           density="compact"
+          :disabled="sourceSuperpathRequired"
           hide-details
           label="Use AAS superpath endpoints for source Submodels"
         />
@@ -111,6 +112,7 @@
           v-model="destinationUseSuperpath"
           class="mt-n2 mb-4"
           density="compact"
+          :disabled="destinationSuperpathRequired"
           hide-details
           label="Use AAS superpath endpoints for destination Submodels"
         />
@@ -175,6 +177,10 @@
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
   import { useNavigationStore } from '@/store/NavigationStore'
   import { base64Encode } from '@/utils/EncodeDecodeUtils'
+  import {
+    getActiveComponentUrlForTemplate,
+    usesSubmodelSuperpath,
+  } from '@/utils/InfrastructureUtils'
 
   // Module shortcuts definition - available when this module is active
   export const shortcuts: PageShortcutDefinitions = () => [
@@ -270,6 +276,12 @@
       ) || null
     )
   })
+  const sourceSuperpathRequired = computed(() =>
+    selectedInfrastructure.value ? usesSubmodelSuperpath(selectedInfrastructure.value) : false,
+  )
+  const destinationSuperpathRequired = computed(() =>
+    destinationInfrastructure.value ? usesSubmodelSuperpath(destinationInfrastructure.value) : false,
+  )
 
   // Pre-select default infrastructure when component mounts
   onMounted(() => {
@@ -278,10 +290,12 @@
     }
   })
 
-  function hasConfiguredSubmodelRepo (infra: (typeof infrastructureStore.getInfrastructures)[number] | null): boolean {
+  function shouldUseSubmodelSuperpath (
+    infra: (typeof infrastructureStore.getInfrastructures)[number] | null,
+  ): boolean {
     if (!infra) return false
-    const submodelRepoUrl = infra.components.SubmodelRepo.url
-    return submodelRepoUrl !== null && submodelRepoUrl.trim() !== ''
+    return usesSubmodelSuperpath(infra)
+      || getActiveComponentUrlForTemplate(infra, 'SubmodelRepo') === ''
   }
 
   // Filter source infrastructures based on selected import mode
@@ -289,16 +303,16 @@
     return infrastructureStore.getInfrastructures
       .filter(infra => {
         if (isAssetIdMode.value) {
-          const discoveryUrl = infra.components.AASDiscovery.url
-          return discoveryUrl && discoveryUrl.trim() !== ''
+          return getActiveComponentUrlForTemplate(infra, 'AASDiscovery') !== ''
         }
-        const aasRepoUrl = infra.components.AASRepo.url
-        return aasRepoUrl && aasRepoUrl.trim() !== ''
+        return getActiveComponentUrlForTemplate(infra, 'AASRepo') !== ''
       })
       .map(infra => ({
         id: infra.id,
         label: infra.name,
-        sourceUrl: isAssetIdMode.value ? infra.components.AASDiscovery.url : infra.components.AASRepo.url,
+        sourceUrl: isAssetIdMode.value
+          ? getActiveComponentUrlForTemplate(infra, 'AASDiscovery')
+          : getActiveComponentUrlForTemplate(infra, 'AASRepo'),
       }))
   })
 
@@ -306,13 +320,12 @@
   const destinationInfrastructureItems = computed(() => {
     return infrastructureStore.getInfrastructures
       .filter(infra => {
-        const aasRepoUrl = infra.components.AASRepo.url
-        return aasRepoUrl && aasRepoUrl.trim() !== ''
+        return getActiveComponentUrlForTemplate(infra, 'AASRepo') !== ''
       })
       .map(infra => ({
         id: infra.id,
         label: infra.name + (infra.isDefault ? ' (Default)' : ''),
-        aasRepoUrl: infra.components.AASRepo.url,
+        aasRepoUrl: getActiveComponentUrlForTemplate(infra, 'AASRepo'),
       }))
   })
 
@@ -342,11 +355,11 @@
   })
 
   watch(selectedInfrastructure, infra => {
-    sourceUseSuperpath.value = !hasConfiguredSubmodelRepo(infra)
+    sourceUseSuperpath.value = shouldUseSubmodelSuperpath(infra)
   })
 
   watch(destinationInfrastructure, infra => {
-    destinationUseSuperpath.value = !hasConfiguredSubmodelRepo(infra)
+    destinationUseSuperpath.value = shouldUseSubmodelSuperpath(infra)
   })
 
   function buildAasEndpointFromRepo (aasRepoUrl: string, aasId: string): string {
@@ -435,7 +448,10 @@
           }
           aasId = selectedDiscoveredAasId.value
         } else {
-          const sourceDiscoveryUrl = selectedInfrastructure.value.components.AASDiscovery.url
+          const sourceDiscoveryUrl = getActiveComponentUrlForTemplate(
+            selectedInfrastructure.value,
+            'AASDiscovery',
+          )
           const discoveredIds = await getAasIds(trimmedImportIdentifier, sourceDiscoveryUrl)
 
           if (discoveredIds.length === 0) {
@@ -467,7 +483,7 @@
         throw new Error('Could not resolve a valid AAS ID for import')
       }
 
-      const sourceAasRepoUrl = selectedInfrastructure.value.components.AASRepo.url.trim()
+      const sourceAasRepoUrl = getActiveComponentUrlForTemplate(selectedInfrastructure.value, 'AASRepo')
       if (sourceAasRepoUrl === '') {
         throw new Error('Selected source infrastructure has no AAS Repository configured')
       }
@@ -475,10 +491,14 @@
       // Step 1: Get AAS Endpoint
       let aasEndpoint = buildAasEndpointFromRepo(sourceAasRepoUrl, aasId)
 
-      if (selectedInfrastructure?.value?.components.AASRegistry.url.trim() !== '') {
+      const sourceAasRegistryUrl = getActiveComponentUrlForTemplate(
+        selectedInfrastructure.value,
+        'AASRegistry',
+      )
+      if (sourceAasRegistryUrl !== '') {
         aasEndpoint = await getAasEndpointById(
           aasId,
-          selectedInfrastructure?.value?.components.AASRegistry.url,
+          sourceAasRegistryUrl,
         )
       }
 
@@ -500,7 +520,7 @@
               smEndpoint = buildSubmodelEndpointFromSuperpath(aasEndpoint, smId)
             } else {
               const sourceSubmodelRepoUrl
-                = selectedInfrastructure?.value?.components.SubmodelRepo.url.trim()
+                = getActiveComponentUrlForTemplate(selectedInfrastructure.value, 'SubmodelRepo')
               if (sourceSubmodelRepoUrl === '') {
                 throw new Error(
                   'Source infrastructure has no Submodel Repository configured and source superpath is disabled',
@@ -514,18 +534,21 @@
 
             if (
               !sourceUseSuperpath.value
-              && selectedInfrastructure?.value?.components.SubmodelRegistry.url.trim() !== ''
+              && getActiveComponentUrlForTemplate(selectedInfrastructure.value, 'SubmodelRegistry') !== ''
             ) {
               smEndpoint = await getSmEndpointById(
                 smId,
-                selectedInfrastructure?.value?.components.SubmodelRegistry.url,
+                getActiveComponentUrlForTemplate(selectedInfrastructure.value, 'SubmodelRegistry'),
               )
             }
 
             const submodel = await fetchSm(smEndpoint)
 
             // Fetch Concept Descriptions if configured
-            const cdRepoUrl = selectedInfrastructure?.value?.components.ConceptDescriptionRepo.url.trim()
+            const cdRepoUrl = getActiveComponentUrlForTemplate(
+              selectedInfrastructure.value,
+              'ConceptDescriptionRepo',
+            )
             if (cdRepoUrl !== '') {
               const cds = await fetchAllConceptDescriptions(submodel, smEndpoint, cdRepoUrl)
               if (cds && cds.length > 0) {
@@ -543,16 +566,23 @@
       await infrastructureStore.dispatchSelectInfrastructure(destinationInfrastructure.value.id)
       delete aas.endpoints
 
-      const destinationAasRepoUrl = destinationInfrastructure.value.components.AASRepo.url.trim()
+      const destinationAasRepoUrl = getActiveComponentUrlForTemplate(
+        destinationInfrastructure.value,
+        'AASRepo',
+      )
       if (destinationAasRepoUrl === '') {
         throw new Error('Selected destination infrastructure has no AAS Repository configured')
       }
 
       let destinationAasEndpoint = buildAasEndpointFromRepo(destinationAasRepoUrl, aasId)
-      if (destinationInfrastructure.value.components.AASRegistry.url.trim() !== '') {
+      const destinationAasRegistryUrl = getActiveComponentUrlForTemplate(
+        destinationInfrastructure.value,
+        'AASRegistry',
+      )
+      if (destinationAasRegistryUrl !== '') {
         destinationAasEndpoint = await getAasEndpointById(
           aasId,
-          destinationInfrastructure.value.components.AASRegistry.url,
+          destinationAasRegistryUrl,
         )
       }
 

--- a/aas-web-ui/src/pages/modules/CompanyDataPortal/index.vue
+++ b/aas-web-ui/src/pages/modules/CompanyDataPortal/index.vue
@@ -140,6 +140,7 @@
     inheritAttrs: false,
     isDesktopModule: true,
     isMobileModule: false,
+    supportedInfrastructureTemplates: ['mono-repo', 'mono-all'],
   })
 
   const model = ref(0)

--- a/aas-web-ui/src/pages/modules/PcfProcess/index.vue
+++ b/aas-web-ui/src/pages/modules/PcfProcess/index.vue
@@ -15,6 +15,7 @@
     isDesktopModule: true,
     isMobileModule: true,
     moduleTitle: 'PCF Process',
+    supportedInfrastructureTemplates: ['full', 'mono-repo', 'mono-all'],
   })
 
   const step = ref(1)

--- a/aas-web-ui/src/pages/modules/README.md
+++ b/aas-web-ui/src/pages/modules/README.md
@@ -6,6 +6,19 @@ Vue components added here will be automatically registered with the AAS Web UI a
 Modules can reference/use vue components that are located in the [components](../../components/) directory.  
 This way, you can create reusable components that can be used in multiple modules.
 
+## Module Visibility
+
+Modules can limit themselves to specific infrastructure templates by adding
+`supportedInfrastructureTemplates` to `defineOptions`. This setting is optional; when it is omitted or
+empty, the module is available for all infrastructure templates.
+
+```ts
+defineOptions({
+    moduleTitle: 'My Module',
+    supportedInfrastructureTemplates: ['full', 'mono-repo', 'mono-all'],
+});
+```
+
 ## Optional Nested Module Routes
 
 Recommended structure for modules with nested routes:

--- a/aas-web-ui/src/router.ts
+++ b/aas-web-ui/src/router.ts
@@ -18,6 +18,7 @@ import { useAASStore } from '@/store/AASDataStore'
 import { useEnvStore } from '@/store/EnvironmentStore'
 import { useInfrastructureStore } from '@/store/InfrastructureStore'
 import { useNavigationStore } from '@/store/NavigationStore'
+import { supportsInfrastructureTemplate } from '@/utils/InfrastructureUtils'
 import {
   buildValidatedModuleChildRoutes,
   type ModuleRouteManifest,
@@ -170,6 +171,7 @@ async function generateModuleRoutes (): Promise<Array<RouteRecordRaw>> {
     const isOnlyVisibleWithSelectedAas = moduleComponent.default?.isOnlyVisibleWithSelectedAas ?? false
     const isOnlyVisibleWithSelectedNode = moduleComponent.default?.isOnlyVisibleWithSelectedNode ?? false
     const visibleOnRoutes = moduleComponent.default?.visibleOnRoutes ?? []
+    const supportedInfrastructureTemplates = moduleComponent.default?.supportedInfrastructureTemplates ?? []
     let preserveRouteQuery = moduleComponent.default?.preserveRouteQuery ?? false
 
     // Overwrite preserveRouteQuery
@@ -187,6 +189,7 @@ async function generateModuleRoutes (): Promise<Array<RouteRecordRaw>> {
       isOnlyVisibleWithSelectedAas,
       isOnlyVisibleWithSelectedNode,
       visibleOnRoutes,
+      supportedInfrastructureTemplates,
       preserveRouteQuery,
     }
 
@@ -339,6 +342,14 @@ export async function createAppRouter (): Promise<Router> {
     // Module constraints / visibility
     const meta = (record.meta || {}) as Record<string, unknown>
     if (meta.isVisibleModule === false) {
+      return 'AASViewer'
+    }
+    if (
+      !supportsInfrastructureTemplate(
+        meta.supportedInfrastructureTemplates,
+        infrastructureStore.getSelectedInfrastructure,
+      )
+    ) {
       return 'AASViewer'
     }
     if (meta.isOnlyVisibleWithSelectedAas && (!query || !Object.hasOwn(query, 'aas') || !String(query.aas).trim())) {
@@ -837,6 +848,15 @@ export async function createAppRouter (): Promise<Router> {
     const cleanedRoute = removeInvalidQueryParamsForRoute(to)
     if (cleanedRoute) {
       return cleanedRoute
+    }
+
+    if (
+      !supportsInfrastructureTemplate(
+        to.meta?.supportedInfrastructureTemplates,
+        infrastructureStore.getSelectedInfrastructure,
+      )
+    ) {
+      return { name: 'AASViewer', replace: true }
     }
 
     const displayRoute = handleSingleAasAndDeviceRouting(to)

--- a/aas-web-ui/src/store/InfrastructureStore.ts
+++ b/aas-web-ui/src/store/InfrastructureStore.ts
@@ -13,7 +13,7 @@ import { useInfrastructureStorage } from '@/composables/Infrastructure/useInfras
 import { useRequestHandling } from '@/composables/RequestHandling'
 import { useEnvStore } from '@/store/EnvironmentStore'
 import { useNavigationStore } from '@/store/NavigationStore'
-import { getActiveComponentKeys } from '@/utils/InfrastructureUtils'
+import { getActiveComponentKeys, isComponentActiveForTemplate } from '@/utils/InfrastructureUtils'
 import { stripLastCharacter } from '@/utils/StringUtils'
 
 export const useInfrastructureStore = defineStore('infrastructureStore', () => {
@@ -140,12 +140,24 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
     return infrastructures.value.find(infra => infra.id === selectedInfrastructureId.value) || null
   })
   const getOpenInfrastructureEditMode = computed(() => openInfrastructureEditMode.value)
-  const getAASDiscoveryURL = computed(() => AASDiscoveryURL.value)
-  const getAASRegistryURL = computed(() => AASRegistryURL.value)
-  const getSubmodelRegistryURL = computed(() => SubmodelRegistryURL.value)
-  const getAASRepoURL = computed(() => AASRepoURL.value)
-  const getSubmodelRepoURL = computed(() => SubmodelRepoURL.value)
-  const getConceptDescriptionRepoURL = computed(() => ConceptDescriptionRepoURL.value)
+  function getActiveComponentUrl (componentKey: BaSyxComponentKey, url: string): string {
+    const selectedInfra = getSelectedInfrastructure.value
+    if (!selectedInfra) {
+      return url
+    }
+    return isComponentActiveForTemplate(selectedInfra, componentKey) ? url : ''
+  }
+
+  const getAASDiscoveryURL = computed(() => getActiveComponentUrl('AASDiscovery', AASDiscoveryURL.value))
+  const getAASRegistryURL = computed(() => getActiveComponentUrl('AASRegistry', AASRegistryURL.value))
+  const getSubmodelRegistryURL = computed(() =>
+    getActiveComponentUrl('SubmodelRegistry', SubmodelRegistryURL.value),
+  )
+  const getAASRepoURL = computed(() => getActiveComponentUrl('AASRepo', AASRepoURL.value))
+  const getSubmodelRepoURL = computed(() => getActiveComponentUrl('SubmodelRepo', SubmodelRepoURL.value))
+  const getConceptDescriptionRepoURL = computed(() =>
+    getActiveComponentUrl('ConceptDescriptionRepo', ConceptDescriptionRepoURL.value),
+  )
   const getBasyxComponents = computed(() => basyxComponents)
   const getIsAuthenticating = computed(() => isAuthenticating.value)
   const getIsTestingConnections = computed(() => isTestingConnections.value)

--- a/aas-web-ui/src/store/InfrastructureStore.ts
+++ b/aas-web-ui/src/store/InfrastructureStore.ts
@@ -13,6 +13,7 @@ import { useInfrastructureStorage } from '@/composables/Infrastructure/useInfras
 import { useRequestHandling } from '@/composables/RequestHandling'
 import { useEnvStore } from '@/store/EnvironmentStore'
 import { useNavigationStore } from '@/store/NavigationStore'
+import { getActiveComponentKeys } from '@/utils/InfrastructureUtils'
 import { stripLastCharacter } from '@/utils/StringUtils'
 
 export const useInfrastructureStore = defineStore('infrastructureStore', () => {
@@ -351,15 +352,14 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
 
       saveInfrastructuresToStorage()
 
-      // If this is the selected infrastructure, update the URL refs
-      // if (selectedInfrastructureId.value === infrastructure.id) {
-      //     AASDiscoveryURL.value = infrastructure.components.AASDiscovery.url;
-      //     AASRegistryURL.value = infrastructure.components.AASRegistry.url;
-      //     SubmodelRegistryURL.value = infrastructure.components.SubmodelRegistry.url;
-      //     AASRepoURL.value = infrastructure.components.AASRepo.url;
-      //     SubmodelRepoURL.value = infrastructure.components.SubmodelRepo.url;
-      //     ConceptDescriptionRepoURL.value = infrastructure.components.ConceptDescriptionRepo.url;
-      // }
+      if (selectedInfrastructureId.value === infrastructure.id) {
+        AASDiscoveryURL.value = infrastructure.components.AASDiscovery.url
+        AASRegistryURL.value = infrastructure.components.AASRegistry.url
+        SubmodelRegistryURL.value = infrastructure.components.SubmodelRegistry.url
+        AASRepoURL.value = infrastructure.components.AASRepo.url
+        SubmodelRepoURL.value = infrastructure.components.SubmodelRepo.url
+        ConceptDescriptionRepoURL.value = infrastructure.components.ConceptDescriptionRepo.url
+      }
     }
   }
 
@@ -512,7 +512,15 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
       return
     }
 
+    const activeKeys = getActiveComponentKeys(selectedInfra)
+
     for (const repoKey of keys) {
+      if (!activeKeys.includes(repoKey)) {
+        basyxComponents[repoKey].connected = null
+        basyxComponents[repoKey].loading = false
+        continue
+      }
+
       // Use URL from the selected infrastructure
       const infraUrl = selectedInfra.components[repoKey]?.url || ''
 

--- a/aas-web-ui/src/store/NavigationStore.ts
+++ b/aas-web-ui/src/store/NavigationStore.ts
@@ -38,11 +38,11 @@ export const useNavigationStore = defineStore('navigationStore', () => {
   const isMobile = ref(false)
   const platform = ref<PlatformType>({} as PlatformType)
   const plugins = ref<PluginType[]>([])
-  const triggerAASListReload = ref(false)
-  const clearAASList = ref(false)
-  const clearTreeview = ref(false)
-  const triggerAASListScroll = ref(false)
-  const triggerTreeviewReload = ref(false)
+  const triggerAASListReload = ref(0)
+  const clearAASList = ref(0)
+  const clearTreeview = ref(0)
+  const triggerAASListScroll = ref(0)
+  const triggerTreeviewReload = ref(0)
   const urlQuery = ref<LocationQuery>({} as LocationQuery)
   const moduleRoutes = ref<Array<ModuleNavigationRoute>>([])
 
@@ -102,33 +102,23 @@ export const useNavigationStore = defineStore('navigationStore', () => {
   }
 
   function dispatchTriggerAASListReload (): void {
-    triggerAASListReload.value = !triggerAASListReload.value
-
-    setTimeout(() => {
-      // Reset dispatchTriggerAASListReload after 100 ms
-      triggerAASListReload.value = false
-    }, 100)
+    triggerAASListReload.value += 1
   }
 
   function dispatchClearAASList (): void {
-    clearAASList.value = !clearAASList.value
+    clearAASList.value += 1
   }
 
   function dispatchClearTreeview (): void {
-    clearTreeview.value = !clearTreeview.value
+    clearTreeview.value += 1
   }
 
   function dispatchTriggerAASListScroll (): void {
-    triggerAASListScroll.value = !triggerAASListScroll.value
+    triggerAASListScroll.value += 1
   }
 
   function dispatchTriggerTreeviewReload (): void {
-    triggerTreeviewReload.value = !triggerTreeviewReload.value
-
-    setTimeout(() => {
-      // Reset dispatchTriggerTreeviewReload after 100 ms
-      triggerTreeviewReload.value = false
-    }, 100)
+    triggerTreeviewReload.value += 1
   }
 
   function dispatchUrlQuery (query: LocationQuery): void {

--- a/aas-web-ui/src/types/Application.ts
+++ b/aas-web-ui/src/types/Application.ts
@@ -1,3 +1,5 @@
+import type { InfrastructureTemplate } from '@/types/Infrastructure'
+
 export interface SnackbarType {
   status: boolean
   timeout?: number
@@ -58,6 +60,7 @@ export interface ModuleNavigationRouteMeta {
   isOnlyVisibleWithSelectedAas?: boolean
   isOnlyVisibleWithSelectedNode?: boolean
   visibleOnRoutes?: Array<string>
+  supportedInfrastructureTemplates?: InfrastructureTemplate[]
   preserveRouteQuery?: boolean
 }
 

--- a/aas-web-ui/src/types/Infrastructure.ts
+++ b/aas-web-ui/src/types/Infrastructure.ts
@@ -6,6 +6,11 @@ import type { BaSyxComponentKey } from '@/types/BaSyx'
 export type SecurityType = 'No Authentication' | 'Basic Authentication' | 'Bearer Token' | 'OAuth2'
 
 /**
+ * Supported infrastructure topology templates
+ */
+export type InfrastructureTemplate = 'full' | 'identifiable' | 'mono-repo' | 'mono-all' | 'catena-x'
+
+/**
  * Basic authentication credentials
  */
 export interface BasicAuthData {
@@ -68,6 +73,7 @@ export interface ComponentConfig {
 export interface InfrastructureConfig {
   id: string
   name: string
+  template: InfrastructureTemplate
   isDefault?: boolean
   auth?: InfrastructureAuth
   token?: TokenData
@@ -183,6 +189,7 @@ export interface YamlSecurityConfig {
  */
 export interface YamlInfrastructureConfig {
   name?: string
+  template?: InfrastructureTemplate | string
   components: {
     aasDiscovery?: YamlComponentConfig
     aasRegistry?: YamlComponentConfig
@@ -190,6 +197,9 @@ export interface YamlInfrastructureConfig {
     aasRepository?: YamlComponentConfig
     submodelRepository?: YamlComponentConfig
     conceptDescriptionRepository?: YamlComponentConfig
+    aasEnvironment?: YamlComponentConfig
+    digitalTwinRegistry?: YamlComponentConfig
+    submodelService?: YamlComponentConfig
   }
   security: YamlSecurityConfig
 }

--- a/aas-web-ui/src/utils/InfrastructureUtils.ts
+++ b/aas-web-ui/src/utils/InfrastructureUtils.ts
@@ -222,10 +222,10 @@ export function getEndpointFieldValue (
   for (const componentKey of field.componentKeys) {
     const url = components[componentKey]?.url?.trim() ?? ''
     if (url !== '') {
-      return components[componentKey].url
+      return url
     }
   }
-  return components[field.componentKeys[0]]?.url ?? ''
+  return components[field.componentKeys[0]]?.url?.trim() ?? ''
 }
 
 export function setEndpointFieldValue (

--- a/aas-web-ui/src/utils/InfrastructureUtils.ts
+++ b/aas-web-ui/src/utils/InfrastructureUtils.ts
@@ -1,5 +1,27 @@
 import type { BaSyxComponentKey } from '@/types/BaSyx'
-import type { InfrastructureConfig } from '@/types/Infrastructure'
+import type { InfrastructureConfig, InfrastructureTemplate } from '@/types/Infrastructure'
+
+export type InfrastructureEndpointFieldKey
+  = BaSyxComponentKey | 'AASEnvironment' | 'DigitalTwinRegistry' | 'SubmodelService'
+
+export interface InfrastructureEndpointField {
+  key: InfrastructureEndpointFieldKey
+  label: string
+  yamlKey: string
+  componentKeys: BaSyxComponentKey[]
+}
+
+export interface InfrastructureTemplateDefinition {
+  value: InfrastructureTemplate
+  label: string
+  description: string
+  endpointFields: InfrastructureEndpointField[]
+  usesSubmodelSuperpath: boolean
+}
+
+export type InfrastructureAasUploadMode = 'client' | 'server'
+
+export const DEFAULT_INFRASTRUCTURE_TEMPLATE: InfrastructureTemplate = 'full'
 
 /**
  * Get human-readable label for a BaSyx component key
@@ -17,12 +39,227 @@ export function getComponentLabel (key: BaSyxComponentKey): string {
 }
 
 /**
- * Get summary text for infrastructure configuration
- * Returns count of configured components vs total
+ * List of all BaSyx component keys in display order
  */
-export function getInfrastructureSummary (infra: InfrastructureConfig, totalComponents = 6): string {
-  const configuredCount = Object.values(infra.components).filter(comp => comp.url.trim() !== '').length
-  return `${configuredCount} of ${totalComponents} components configured`
+export const BASYX_COMPONENT_KEYS: BaSyxComponentKey[] = [
+  'AASDiscovery',
+  'AASRegistry',
+  'SubmodelRegistry',
+  'AASRepo',
+  'SubmodelRepo',
+  'ConceptDescriptionRepo',
+]
+
+const singleComponentEndpointFields: Record<BaSyxComponentKey, InfrastructureEndpointField> = {
+  AASDiscovery: {
+    key: 'AASDiscovery',
+    label: 'AAS Discovery',
+    yamlKey: 'aasDiscovery',
+    componentKeys: ['AASDiscovery'],
+  },
+  AASRegistry: {
+    key: 'AASRegistry',
+    label: 'AAS Registry',
+    yamlKey: 'aasRegistry',
+    componentKeys: ['AASRegistry'],
+  },
+  SubmodelRegistry: {
+    key: 'SubmodelRegistry',
+    label: 'Submodel Registry',
+    yamlKey: 'submodelRegistry',
+    componentKeys: ['SubmodelRegistry'],
+  },
+  AASRepo: {
+    key: 'AASRepo',
+    label: 'AAS Repository',
+    yamlKey: 'aasRepository',
+    componentKeys: ['AASRepo'],
+  },
+  SubmodelRepo: {
+    key: 'SubmodelRepo',
+    label: 'Submodel Repository',
+    yamlKey: 'submodelRepository',
+    componentKeys: ['SubmodelRepo'],
+  },
+  ConceptDescriptionRepo: {
+    key: 'ConceptDescriptionRepo',
+    label: 'Concept Description Repository',
+    yamlKey: 'conceptDescriptionRepository',
+    componentKeys: ['ConceptDescriptionRepo'],
+  },
+}
+
+export const INFRASTRUCTURE_TEMPLATE_DEFINITIONS: Record<
+  InfrastructureTemplate,
+  InfrastructureTemplateDefinition
+> = {
+  'full': {
+    value: 'full',
+    label: 'Full',
+    description: 'Separate discovery, registries, repositories, and concept description repository.',
+    endpointFields: BASYX_COMPONENT_KEYS.map(key => singleComponentEndpointFields[key]),
+    usesSubmodelSuperpath: false,
+  },
+  'identifiable': {
+    value: 'identifiable',
+    label: 'Identifiable',
+    description: 'AAS Repository only; submodels are accessed through shell superpaths.',
+    endpointFields: [singleComponentEndpointFields.AASRepo],
+    usesSubmodelSuperpath: true,
+  },
+  'mono-repo': {
+    value: 'mono-repo',
+    label: 'Mono Repo',
+    description: 'Separate discovery and registries with one AAS Environment for all repositories.',
+    endpointFields: [
+      singleComponentEndpointFields.AASDiscovery,
+      singleComponentEndpointFields.AASRegistry,
+      singleComponentEndpointFields.SubmodelRegistry,
+      {
+        key: 'AASEnvironment',
+        label: 'AAS Environment',
+        yamlKey: 'aasEnvironment',
+        componentKeys: ['AASRepo', 'SubmodelRepo', 'ConceptDescriptionRepo'],
+      },
+    ],
+    usesSubmodelSuperpath: false,
+  },
+  'mono-all': {
+    value: 'mono-all',
+    label: 'Mono All',
+    description: 'One AAS Environment exposes all full-template component APIs.',
+    endpointFields: [
+      {
+        key: 'AASEnvironment',
+        label: 'AAS Environment',
+        yamlKey: 'aasEnvironment',
+        componentKeys: BASYX_COMPONENT_KEYS,
+      },
+    ],
+    usesSubmodelSuperpath: false,
+  },
+  'catena-x': {
+    value: 'catena-x',
+    label: 'Catena-X',
+    description: 'Digital Twin Registry plus Submodel Service.',
+    endpointFields: [
+      {
+        key: 'DigitalTwinRegistry',
+        label: 'Digital Twin Registry',
+        yamlKey: 'digitalTwinRegistry',
+        componentKeys: ['AASDiscovery', 'AASRegistry'],
+      },
+      {
+        key: 'SubmodelService',
+        label: 'Submodel Service',
+        yamlKey: 'submodelService',
+        componentKeys: ['SubmodelRepo'],
+      },
+    ],
+    usesSubmodelSuperpath: false,
+  },
+}
+
+export const INFRASTRUCTURE_TEMPLATE_OPTIONS = Object.values(INFRASTRUCTURE_TEMPLATE_DEFINITIONS)
+
+export function isInfrastructureTemplate (value: unknown): value is InfrastructureTemplate {
+  return typeof value === 'string' && Object.hasOwn(INFRASTRUCTURE_TEMPLATE_DEFINITIONS, value)
+}
+
+export function normalizeInfrastructureTemplate (value: unknown): InfrastructureTemplate {
+  return isInfrastructureTemplate(value) ? value : DEFAULT_INFRASTRUCTURE_TEMPLATE
+}
+
+export function getInfrastructureTemplate (
+  templateOrInfra?: InfrastructureTemplate | string | Pick<InfrastructureConfig, 'template'> | null,
+): InfrastructureTemplate {
+  return typeof templateOrInfra === 'string'
+    ? normalizeInfrastructureTemplate(templateOrInfra)
+    : normalizeInfrastructureTemplate(templateOrInfra?.template)
+}
+
+export function getInfrastructureTemplateDefinition (
+  templateOrInfra?: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null,
+): InfrastructureTemplateDefinition {
+  const template = typeof templateOrInfra === 'string'
+    ? normalizeInfrastructureTemplate(templateOrInfra)
+    : getInfrastructureTemplate(templateOrInfra)
+  return INFRASTRUCTURE_TEMPLATE_DEFINITIONS[template]
+}
+
+export function getEndpointFieldsForTemplate (
+  templateOrInfra?: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null,
+): InfrastructureEndpointField[] {
+  return getInfrastructureTemplateDefinition(templateOrInfra).endpointFields
+}
+
+export function getActiveComponentKeys (
+  templateOrInfra?: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null,
+): BaSyxComponentKey[] {
+  return Array.from(
+    new Set(getEndpointFieldsForTemplate(templateOrInfra).flatMap(field => field.componentKeys)),
+  )
+}
+
+export function isComponentActiveForTemplate (
+  templateOrInfra: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null | undefined,
+  componentKey: BaSyxComponentKey,
+): boolean {
+  return getActiveComponentKeys(templateOrInfra).includes(componentKey)
+}
+
+export function getEndpointFieldByKey (
+  templateOrInfra: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null | undefined,
+  fieldKey: InfrastructureEndpointFieldKey,
+): InfrastructureEndpointField | undefined {
+  return getEndpointFieldsForTemplate(templateOrInfra).find(field => field.key === fieldKey)
+}
+
+export function getEndpointFieldValue (
+  components: InfrastructureConfig['components'],
+  field: InfrastructureEndpointField,
+): string {
+  for (const componentKey of field.componentKeys) {
+    const url = components[componentKey]?.url?.trim() ?? ''
+    if (url !== '') {
+      return components[componentKey].url
+    }
+  }
+  return components[field.componentKeys[0]]?.url ?? ''
+}
+
+export function setEndpointFieldValue (
+  components: InfrastructureConfig['components'],
+  field: InfrastructureEndpointField,
+  url: string,
+): void {
+  for (const componentKey of field.componentKeys) {
+    components[componentKey].url = url
+  }
+}
+
+export function usesSubmodelSuperpath (
+  templateOrInfra?: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null,
+): boolean {
+  return getInfrastructureTemplateDefinition(templateOrInfra).usesSubmodelSuperpath
+}
+
+export function getDefaultAasUploadMode (
+  templateOrInfra?: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null,
+): InfrastructureAasUploadMode {
+  const template = getInfrastructureTemplate(templateOrInfra)
+  return template === 'mono-repo' || template === 'mono-all' ? 'server' : 'client'
+}
+
+/**
+ * Get summary text for infrastructure configuration.
+ */
+export function getInfrastructureSummary (infra: InfrastructureConfig): string {
+  const endpointFields = getEndpointFieldsForTemplate(infra)
+  const configuredCount = endpointFields.filter(
+    field => getEndpointFieldValue(infra.components, field).trim() !== '',
+  ).length
+  return `${configuredCount} of ${endpointFields.length} endpoints configured`
 }
 
 /**
@@ -38,15 +275,3 @@ export function requiredRule (value: string): string | boolean {
 export function getRedirectUri (): string {
   return `${window.location.origin}${window.location.pathname}/oauth2/callback`
 }
-
-/**
- * List of all BaSyx component keys in display order
- */
-export const BASYX_COMPONENT_KEYS: BaSyxComponentKey[] = [
-  'AASDiscovery',
-  'AASRegistry',
-  'SubmodelRegistry',
-  'AASRepo',
-  'SubmodelRepo',
-  'ConceptDescriptionRepo',
-]

--- a/aas-web-ui/src/utils/InfrastructureUtils.ts
+++ b/aas-web-ui/src/utils/InfrastructureUtils.ts
@@ -244,6 +244,22 @@ export function usesSubmodelSuperpath (
   return getInfrastructureTemplateDefinition(templateOrInfra).usesSubmodelSuperpath
 }
 
+export function supportsInfrastructureTemplate (
+  supportedTemplates: unknown,
+  templateOrInfra?: InfrastructureTemplate | string | Pick<InfrastructureConfig, 'template'> | null,
+): boolean {
+  if (!Array.isArray(supportedTemplates) || supportedTemplates.length === 0) {
+    return true
+  }
+
+  const validSupportedTemplates = supportedTemplates.filter(isInfrastructureTemplate)
+  if (validSupportedTemplates.length === 0) {
+    return true
+  }
+
+  return validSupportedTemplates.includes(getInfrastructureTemplate(templateOrInfra))
+}
+
 export function getDefaultAasUploadMode (
   templateOrInfra?: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null,
 ): InfrastructureAasUploadMode {

--- a/aas-web-ui/src/utils/InfrastructureUtils.ts
+++ b/aas-web-ui/src/utils/InfrastructureUtils.ts
@@ -208,6 +208,17 @@ export function isComponentActiveForTemplate (
   return getActiveComponentKeys(templateOrInfra).includes(componentKey)
 }
 
+export function getActiveComponentUrlForTemplate (
+  infrastructure: Pick<InfrastructureConfig, 'components' | 'template'> | null | undefined,
+  componentKey: BaSyxComponentKey,
+): string {
+  if (!infrastructure || !isComponentActiveForTemplate(infrastructure, componentKey)) {
+    return ''
+  }
+
+  return infrastructure.components[componentKey]?.url?.trim() ?? ''
+}
+
 export function getEndpointFieldByKey (
   templateOrInfra: InfrastructureTemplate | Pick<InfrastructureConfig, 'template'> | null | undefined,
   fieldKey: InfrastructureEndpointFieldKey,

--- a/aas-web-ui/src/utils/ModuleRouteUtils.ts
+++ b/aas-web-ui/src/utils/ModuleRouteUtils.ts
@@ -1,3 +1,4 @@
+import type { InfrastructureTemplate } from '@/types/Infrastructure'
 import type { RouteRecordRaw, RouteRecordSingleView } from 'vue-router'
 
 export type ModuleRouteMeta = {
@@ -11,6 +12,7 @@ export type ModuleRouteMeta = {
   isOnlyVisibleWithSelectedAas?: boolean
   isOnlyVisibleWithSelectedNode?: boolean
   visibleOnRoutes?: Array<string>
+  supportedInfrastructureTemplates?: InfrastructureTemplate[]
   preserveRouteQuery?: boolean
 }
 
@@ -95,6 +97,10 @@ export function buildValidatedModuleChildRoutes (moduleName: string,
         isVisibleModule: parentMeta.isVisibleModule,
         isOnlyVisibleWithSelectedAas: parentMeta.isOnlyVisibleWithSelectedAas,
         isOnlyVisibleWithSelectedNode: parentMeta.isOnlyVisibleWithSelectedNode,
+        supportedInfrastructureTemplates:
+          childRouteDefinition.meta && Object.hasOwn(childRouteDefinition.meta, 'supportedInfrastructureTemplates')
+            ? childRouteDefinition.meta.supportedInfrastructureTemplates
+            : parentMeta.supportedInfrastructureTemplates,
         preserveRouteQuery:
                     childRouteDefinition.meta && Object.hasOwn(childRouteDefinition.meta, 'preserveRouteQuery')
                       ? childRouteDefinition.meta.preserveRouteQuery

--- a/aas-web-ui/tests/composables/ClipboardUtil.test.ts
+++ b/aas-web-ui/tests/composables/ClipboardUtil.test.ts
@@ -16,6 +16,7 @@ const mockDeps = vi.hoisted(() => ({
   dispatchTriggerTreeviewReload: vi.fn(),
   postSubmodel: vi.fn().mockResolvedValue(true),
   postSubmodelElement: vi.fn().mockResolvedValue(true),
+  getSmEndpointById: vi.fn(),
   putAas: vi.fn().mockResolvedValue(true),
   generateIri: vi.fn(() => 'https://example.com/ids/sm/new-id'),
   dispatchSelectedAAS: vi.fn(),
@@ -56,6 +57,7 @@ vi.mock('@/composables/Client/SMRepositoryClient', () => ({
   useSMRepositoryClient: () => ({
     postSubmodel: mockDeps.postSubmodel,
     postSubmodelElement: mockDeps.postSubmodelElement,
+    getSmEndpointById: mockDeps.getSmEndpointById,
   }),
 }))
 
@@ -81,6 +83,9 @@ describe('ClipboardUtil.ts', () => {
     mockState.selectedAAS = { submodels: [] }
     mockState.submodelRepoUrl = 'https://example.test/submodels'
     mockState.clipboardContent = undefined
+    mockDeps.getSmEndpointById.mockImplementation(
+      (submodelId: string) => `${mockState.submodelRepoUrl}/${base64Encode(submodelId)}`,
+    )
   })
 
   it('cleans tree augmentation fields and restores children structure for submodels/collections/entities', () => {

--- a/aas-web-ui/tests/composables/Infrastructure/useComponentConnectionTesting.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useComponentConnectionTesting.test.ts
@@ -1,0 +1,97 @@
+import type { BaSyxComponentKey } from '@/types/BaSyx'
+import type { ComponentConfig } from '@/types/Infrastructure'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useComponentConnectionTesting } from '@/composables/Infrastructure/useComponentConnectionTesting'
+
+const mocks = vi.hoisted(() => {
+  const componentKeys = [
+    'AASDiscovery',
+    'AASRegistry',
+    'SubmodelRegistry',
+    'AASRepo',
+    'SubmodelRepo',
+    'ConceptDescriptionRepo',
+  ] as const
+
+  const components = Object.fromEntries(
+    componentKeys.map(key => [key, { url: `${key}-original`, connected: null }]),
+  ) as Record<BaSyxComponentKey, { url: string, connected: boolean | null }>
+
+  return {
+    components,
+    connectResolvers: {} as Record<string, () => void>,
+    dispatchIsTestingConnections: vi.fn(),
+    connectComponent: vi.fn((componentKey: BaSyxComponentKey) =>
+      new Promise<void>(resolve => {
+        const resolver = (): void => {
+          components[componentKey].connected = true
+          resolve()
+        }
+        mocks.connectResolvers[componentKey] = resolver
+      })),
+  }
+})
+
+vi.mock('@/store/InfrastructureStore', () => ({
+  useInfrastructureStore: () => ({
+    getBasyxComponents: mocks.components,
+    connectComponent: mocks.connectComponent,
+    dispatchIsTestingConnections: mocks.dispatchIsTestingConnections,
+  }),
+}))
+
+function createComponents (): Record<BaSyxComponentKey, ComponentConfig> {
+  return {
+    AASDiscovery: { url: '' },
+    AASRegistry: { url: '' },
+    SubmodelRegistry: { url: '' },
+    AASRepo: { url: 'https://aas-env.example' },
+    SubmodelRepo: { url: '' },
+    ConceptDescriptionRepo: { url: '' },
+  }
+}
+
+async function flushPromises (): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('useComponentConnectionTesting', () => {
+  beforeEach(() => {
+    mocks.dispatchIsTestingConnections.mockClear()
+    mocks.connectComponent.mockClear()
+    mocks.connectResolvers = {}
+
+    for (const [componentKey, component] of Object.entries(mocks.components)) {
+      component.url = `${componentKey}-original`
+      component.connected = null
+    }
+  })
+
+  it('keeps the global testing flag active until all grouped component tests finish', async () => {
+    const connectionTesting = useComponentConnectionTesting()
+
+    const testPromise = connectionTesting.testEndpointField(
+      'mono-repo',
+      'AASEnvironment',
+      createComponents(),
+    )
+
+    expect(mocks.connectComponent).toHaveBeenCalledTimes(3)
+    expect(mocks.dispatchIsTestingConnections).toHaveBeenLastCalledWith(true)
+
+    mocks.connectResolvers.AASRepo()
+    await flushPromises()
+
+    expect(mocks.dispatchIsTestingConnections).toHaveBeenLastCalledWith(true)
+
+    mocks.connectResolvers.SubmodelRepo()
+    mocks.connectResolvers.ConceptDescriptionRepo()
+    await testPromise
+
+    expect(mocks.dispatchIsTestingConnections).toHaveBeenLastCalledWith(false)
+    expect(mocks.components.AASRepo.url).toBe('AASRepo-original')
+    expect(mocks.components.SubmodelRepo.url).toBe('SubmodelRepo-original')
+    expect(mocks.components.ConceptDescriptionRepo.url).toBe('ConceptDescriptionRepo-original')
+  })
+})

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useInfrastructureStorage } from '@/composables/Infrastructure/useInfrastructureStorage'
+
+const mockDeps = vi.hoisted(() => ({
+  loadInfrastructureConfig: vi.fn(),
+  dispatchSnackbar: vi.fn(),
+  authenticateOAuth2ClientCredentials: vi.fn(),
+}))
+
+vi.mock('@/composables/Infrastructure/useInfrastructureConfigLoader', () => ({
+  useInfrastructureConfigLoader: () => ({
+    loadInfrastructureConfig: mockDeps.loadInfrastructureConfig,
+  }),
+}))
+
+vi.mock('@/store/NavigationStore', () => ({
+  useNavigationStore: () => ({
+    dispatchSnackbar: mockDeps.dispatchSnackbar,
+  }),
+}))
+
+vi.mock('@/composables/Auth/OAuth2Auth', () => ({
+  authenticateOAuth2ClientCredentials: mockDeps.authenticateOAuth2ClientCredentials,
+}))
+
+describe('useInfrastructureStorage.ts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+    mockDeps.loadInfrastructureConfig.mockResolvedValue(null)
+  })
+
+  it('normalizes localStorage infrastructures without template to full', async () => {
+    window.localStorage.setItem('basyxInfrastructures', JSON.stringify({
+      selectedInfrastructureId: 'legacy-infra',
+      infrastructures: [
+        {
+          id: 'legacy-infra',
+          name: 'Legacy',
+          components: {
+            AASRepo: { url: 'https://aas-repo.example' },
+          },
+          auth: { securityType: 'No Authentication' },
+        },
+      ],
+    }))
+
+    const { loadInfrastructuresFromStorage } = useInfrastructureStorage()
+    const result = await loadInfrastructuresFromStorage({})
+    const infrastructure = result.infrastructures[0]
+
+    expect(infrastructure.template).toBe('full')
+    expect(infrastructure.components.AASRepo.url).toBe('https://aas-repo.example')
+    expect(infrastructure.components.AASDiscovery.url).toBe('')
+    expect(infrastructure.components.AASRegistry.hasDiscoveryIntegration).toBe(true)
+    expect(infrastructure.components.SubmodelRepo.hasRegistryIntegration).toBe(true)
+    expect(result.selectedInfrastructureId).toBe('legacy-infra')
+  })
+
+  it('persists normalized template values when saving older infrastructure objects', () => {
+    const { saveInfrastructuresToStorage } = useInfrastructureStorage()
+
+    saveInfrastructuresToStorage([
+      {
+        id: 'stored-infra',
+        name: 'Stored',
+        components: {
+          AASDiscovery: { url: '' },
+          AASRegistry: { url: '' },
+          SubmodelRegistry: { url: '' },
+          AASRepo: { url: 'https://aas-repo.example' },
+          SubmodelRepo: { url: '' },
+          ConceptDescriptionRepo: { url: '' },
+        },
+        auth: { securityType: 'No Authentication' },
+      } as any,
+    ], 'stored-infra')
+
+    const stored = JSON.parse(window.localStorage.getItem('basyxInfrastructures') ?? '{}')
+    expect(stored.infrastructures[0].template).toBe('full')
+  })
+})

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureYamlParser.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureYamlParser.test.ts
@@ -1,0 +1,115 @@
+import type { YamlInfrastructuresConfig } from '@/types/Infrastructure'
+import { describe, expect, it } from 'vitest'
+import { useInfrastructureYamlParser } from '@/composables/Infrastructure/useInfrastructureYamlParser'
+
+function createYamlConfig (
+  infrastructure: YamlInfrastructuresConfig['infrastructures'][string],
+): YamlInfrastructuresConfig {
+  return {
+    infrastructures: {
+      default: 'local',
+      local: infrastructure,
+    },
+  }
+}
+
+describe('useInfrastructureYamlParser.ts', () => {
+  it('defaults missing template values to full', () => {
+    const { parseYamlConfig } = useInfrastructureYamlParser()
+
+    const parsed = parseYamlConfig(createYamlConfig({
+      name: 'Local',
+      components: {
+        aasRepository: { baseUrl: 'https://aas-repo.example' },
+      },
+      security: { type: 'none' },
+    }))
+
+    expect(parsed.infrastructures[0].template).toBe('full')
+    expect(parsed.defaultInfrastructureId).toBe('yaml_local')
+  })
+
+  it('falls back to full for invalid template values', () => {
+    const { parseYamlConfig } = useInfrastructureYamlParser()
+
+    const parsed = parseYamlConfig(createYamlConfig({
+      name: 'Invalid Template',
+      template: 'not-a-template',
+      components: {
+        aasRepository: { baseUrl: 'https://aas-repo.example' },
+      },
+      security: { type: 'none' },
+    }))
+
+    expect(parsed.infrastructures[0].template).toBe('full')
+  })
+
+  it.each(['full', 'identifiable', 'mono-repo', 'mono-all', 'catena-x'] as const)(
+    'parses explicit %s template values',
+    template => {
+      const { parseYamlConfig } = useInfrastructureYamlParser()
+
+      const parsed = parseYamlConfig(createYamlConfig({
+        name: template,
+        template,
+        components: {
+          aasRepository: { baseUrl: 'https://aas-repo.example' },
+        },
+        security: { type: 'none' },
+      }))
+
+      expect(parsed.infrastructures[0].template).toBe(template)
+    },
+  )
+
+  it('maps mono-repo AAS Environment URL to repository compatibility slots', () => {
+    const { parseYamlConfig } = useInfrastructureYamlParser()
+
+    const parsed = parseYamlConfig(createYamlConfig({
+      name: 'Mono Repo',
+      template: 'mono-repo',
+      components: {
+        aasDiscovery: { baseUrl: 'https://discovery.example' },
+        aasRegistry: { baseUrl: 'https://aas-registry.example' },
+        submodelRegistry: { baseUrl: 'https://sm-registry.example' },
+        aasEnvironment: {
+          baseUrl: 'https://aas-env.example',
+          hasRegistryIntegration: false,
+        },
+      },
+      security: { type: 'none' },
+    }))
+
+    const components = parsed.infrastructures[0].components
+    expect(components.AASDiscovery.url).toBe('https://discovery.example')
+    expect(components.AASRegistry.url).toBe('https://aas-registry.example')
+    expect(components.SubmodelRegistry.url).toBe('https://sm-registry.example')
+    expect(components.AASRepo.url).toBe('https://aas-env.example')
+    expect(components.SubmodelRepo.url).toBe('https://aas-env.example')
+    expect(components.ConceptDescriptionRepo.url).toBe('https://aas-env.example')
+    expect(components.AASRepo.hasRegistryIntegration).toBe(false)
+    expect(components.SubmodelRepo.hasRegistryIntegration).toBe(false)
+  })
+
+  it('maps Catena-X DTR and Submodel Service URLs to compatibility slots', () => {
+    const { parseYamlConfig } = useInfrastructureYamlParser()
+
+    const parsed = parseYamlConfig(createYamlConfig({
+      name: 'Catena-X',
+      template: 'catena-x',
+      components: {
+        digitalTwinRegistry: { baseUrl: 'https://dtr.example' },
+        submodelService: { baseUrl: 'https://submodel-service.example' },
+      },
+      security: { type: 'oauth2', config: { issuer: 'https://issuer.example', clientId: 'ui' } },
+    }))
+
+    const infrastructure = parsed.infrastructures[0]
+    expect(infrastructure.template).toBe('catena-x')
+    expect(infrastructure.components.AASDiscovery.url).toBe('https://dtr.example')
+    expect(infrastructure.components.AASRegistry.url).toBe('https://dtr.example')
+    expect(infrastructure.components.SubmodelRepo.url).toBe('https://submodel-service.example')
+    expect(infrastructure.components.SubmodelRegistry.url).toBe('')
+    expect(infrastructure.auth?.securityType).toBe('OAuth2')
+  })
+})

--- a/aas-web-ui/tests/composables/ModuleHandling.test.ts
+++ b/aas-web-ui/tests/composables/ModuleHandling.test.ts
@@ -19,6 +19,7 @@ const mockState = {
   moduleRoutes: ref<Array<ModuleNavigationRoute>>([]),
   selectedAas: ref<Record<string, unknown> | null>(null),
   selectedNode: ref<Record<string, unknown> | null>(null),
+  selectedInfrastructure: ref<{ template: string } | null>({ template: 'full' }),
 }
 
 async function importUseModuleHandling () {
@@ -52,6 +53,14 @@ async function importUseModuleHandling () {
     }),
   }))
 
+  vi.doMock('@/store/InfrastructureStore', () => ({
+    useInfrastructureStore: () => ({
+      get getSelectedInfrastructure () {
+        return mockState.selectedInfrastructure.value
+      },
+    }),
+  }))
+
   return import('@/composables/ModuleHandling')
 }
 
@@ -64,6 +73,7 @@ describe('ModuleHandling.ts', () => {
     mockState.isMobile.value = false
     mockState.selectedAas.value = null
     mockState.selectedNode.value = null
+    mockState.selectedInfrastructure.value = { template: 'full' }
     mockState.moduleRoutes.value = [
       createModuleRoute({
         path: '/modules/test-module',
@@ -118,6 +128,73 @@ describe('ModuleHandling.ts', () => {
     const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
 
     expect(filteredRoutes).toHaveLength(0)
+  })
+
+  it('includes modules without explicit infrastructure template restrictions', async () => {
+    mockState.selectedInfrastructure.value = { template: 'catena-x' }
+    mockState.moduleRoutes.value = [
+      createModuleRoute({
+        path: '/modules/default-all',
+        name: 'DefaultAllModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+        },
+      }),
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(1)
+    expect(filteredRoutes[0].name).toBe('DefaultAllModule')
+  })
+
+  it('excludes a module when selected infrastructure template is unsupported', async () => {
+    mockState.selectedInfrastructure.value = { template: 'catena-x' }
+    mockState.moduleRoutes.value = [
+      createModuleRoute({
+        path: '/modules/write-heavy',
+        name: 'WriteHeavyModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+          supportedInfrastructureTemplates: ['full', 'mono-all'],
+        },
+      }),
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(0)
+  })
+
+  it('includes a module when selected infrastructure template is supported', async () => {
+    mockState.selectedInfrastructure.value = { template: 'mono-all' }
+    mockState.moduleRoutes.value = [
+      createModuleRoute({
+        path: '/modules/write-heavy',
+        name: 'WriteHeavyModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+          supportedInfrastructureTemplates: ['full', 'mono-all'],
+        },
+      }),
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(1)
+    expect(filteredRoutes[0].name).toBe('WriteHeavyModule')
   })
 
   it('reacts to route name and store changes when wrapped in computed by callers', async () => {

--- a/aas-web-ui/tests/composables/SMRepositoryClient.test.ts
+++ b/aas-web-ui/tests/composables/SMRepositoryClient.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mockState = vi.hoisted(() => ({
   submodelRepoUrl: 'https://example.test/submodels',
+  aasRepoUrl: 'https://example.test/aas',
+  selectedInfrastructure: { template: 'full' },
+  selectedAAS: {},
 }))
 
 const mockDeps = vi.hoisted(() => ({
@@ -22,6 +25,14 @@ vi.mock('@aas-core-works/aas-core3.1-typescript', () => ({
 vi.mock('@/store/InfrastructureStore', () => ({
   useInfrastructureStore: () => ({
     getSubmodelRepoURL: mockState.submodelRepoUrl,
+    getAASRepoURL: mockState.aasRepoUrl,
+    getSelectedInfrastructure: mockState.selectedInfrastructure,
+  }),
+}))
+
+vi.mock('@/store/AASDataStore', () => ({
+  useAASStore: () => ({
+    getSelectedAAS: mockState.selectedAAS,
   }),
 }))
 
@@ -44,6 +55,9 @@ describe('SMRepositoryClient.ts write contract', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockState.submodelRepoUrl = 'https://example.test/submodels'
+    mockState.aasRepoUrl = 'https://example.test/aas'
+    mockState.selectedInfrastructure = { template: 'full' }
+    mockState.selectedAAS = {}
   })
 
   it('returns false when postSubmodelElement request result is not successful', async () => {
@@ -86,6 +100,37 @@ describe('SMRepositoryClient.ts write contract', () => {
       expect.any(Headers),
       'updating Submodel Element',
       true,
+    )
+  })
+
+  it('resolves identifiable Submodels through AAS superpath endpoints', async () => {
+    mockState.selectedInfrastructure = { template: 'identifiable' }
+    mockDeps.putRequest.mockResolvedValueOnce({ success: true })
+
+    const { base64Encode } = await import('@/utils/EncodeDecodeUtils')
+    const { useSMRepositoryClient } = await import('@/composables/Client/SMRepositoryClient')
+    const { getSmEndpointById, postSubmodel } = useSMRepositoryClient()
+
+    const expectedPath = [
+      'https://example.test/aas/shells',
+      base64Encode('shell-id'),
+      'submodels',
+      base64Encode('submodel-id'),
+    ].join('/')
+
+    expect(getSmEndpointById('submodel-id', 'shell-id')).toBe(expectedPath)
+
+    await expect(
+      postSubmodel({ id: 'submodel-id' } as any, false, 'shell-id'),
+    ).resolves.toBe(true)
+
+    expect(mockDeps.postRequest).not.toHaveBeenCalled()
+    expect(mockDeps.putRequest).toHaveBeenCalledWith(
+      expectedPath,
+      expect.any(String),
+      expect.any(Headers),
+      'creating Submodel via AAS superpath',
+      false,
     )
   })
 })

--- a/aas-web-ui/tests/router/moduleRouteManifest.test.ts
+++ b/aas-web-ui/tests/router/moduleRouteManifest.test.ts
@@ -19,6 +19,7 @@ describe('module manifest child routes', () => {
         isVisibleModule: true,
         isOnlyVisibleWithSelectedAas: true,
         isOnlyVisibleWithSelectedNode: false,
+        supportedInfrastructureTemplates: ['full', 'mono-all'],
         preserveRouteQuery: true,
       },
       {
@@ -37,6 +38,7 @@ describe('module manifest child routes', () => {
     expect(children[0].name).toBe('Dpp__TechnicalData')
     expect(children[0].meta?.isDesktopModule).toBe(true)
     expect(children[0].meta?.isOnlyVisibleWithSelectedAas).toBe(true)
+    expect(children[0].meta?.supportedInfrastructureTemplates).toEqual(['full', 'mono-all'])
     expect(children[0].meta?.preserveRouteQuery).toBe(true)
   })
 

--- a/aas-web-ui/tests/store/NavigationStore.test.ts
+++ b/aas-web-ui/tests/store/NavigationStore.test.ts
@@ -1,0 +1,32 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useNavigationStore } from '@/store/NavigationStore'
+
+describe('NavigationStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('increments reload and clear signals for every dispatch', () => {
+    const navigationStore = useNavigationStore()
+
+    expect(navigationStore.getTriggerAASListReload).toBe(0)
+    expect(navigationStore.getClearAASList).toBe(0)
+    expect(navigationStore.getClearTreeview).toBe(0)
+    expect(navigationStore.getTriggerTreeviewReload).toBe(0)
+
+    navigationStore.dispatchTriggerAASListReload()
+    navigationStore.dispatchTriggerAASListReload()
+    navigationStore.dispatchClearAASList()
+    navigationStore.dispatchClearAASList()
+    navigationStore.dispatchClearTreeview()
+    navigationStore.dispatchClearTreeview()
+    navigationStore.dispatchTriggerTreeviewReload()
+    navigationStore.dispatchTriggerTreeviewReload()
+
+    expect(navigationStore.getTriggerAASListReload).toBe(2)
+    expect(navigationStore.getClearAASList).toBe(2)
+    expect(navigationStore.getClearTreeview).toBe(2)
+    expect(navigationStore.getTriggerTreeviewReload).toBe(2)
+  })
+})

--- a/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
+++ b/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
@@ -72,7 +72,7 @@ describe('InfrastructureUtils.ts', () => {
       field => field.key === 'AASEnvironment',
     )
 
-    components.SubmodelRepo.url = 'https://aas-env.example'
+    components.SubmodelRepo.url = '  https://aas-env.example  '
 
     expect(monoRepoField).toBeDefined()
     expect(getEndpointFieldValue(components, monoRepoField!)).toBe('https://aas-env.example')

--- a/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
+++ b/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
@@ -10,6 +10,7 @@ import {
   getInfrastructureSummary,
   normalizeInfrastructureTemplate,
   setEndpointFieldValue,
+  supportsInfrastructureTemplate,
   usesSubmodelSuperpath,
 } from '@/utils/InfrastructureUtils'
 
@@ -101,5 +102,16 @@ describe('InfrastructureUtils.ts', () => {
     expect(getDefaultAasUploadMode('identifiable')).toBe('client')
     expect(getDefaultAasUploadMode('catena-x')).toBe('client')
     expect(getDefaultAasUploadMode(undefined)).toBe('client')
+  })
+
+  it('defaults module template support to all templates', () => {
+    expect(supportsInfrastructureTemplate(undefined, 'catena-x')).toBe(true)
+    expect(supportsInfrastructureTemplate([], 'catena-x')).toBe(true)
+  })
+
+  it('checks explicit module template support lists', () => {
+    expect(supportsInfrastructureTemplate(['full', 'mono-all'], 'mono-all')).toBe(true)
+    expect(supportsInfrastructureTemplate(['full', 'mono-all'], 'catena-x')).toBe(false)
+    expect(supportsInfrastructureTemplate(['mono-repo'], createInfrastructure('mono-repo'))).toBe(true)
   })
 })

--- a/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
+++ b/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
@@ -6,6 +6,7 @@ import {
   getActiveComponentKeys,
   getDefaultAasUploadMode,
   getEndpointFieldsForTemplate,
+  getEndpointFieldValue,
   getInfrastructureSummary,
   normalizeInfrastructureTemplate,
   setEndpointFieldValue,
@@ -62,6 +63,18 @@ describe('InfrastructureUtils.ts', () => {
     setEndpointFieldValue(components, monoAllField, 'https://aas-env.example')
 
     expect(BASYX_COMPONENT_KEYS.every(key => components[key].url === 'https://aas-env.example')).toBe(true)
+  })
+
+  it('uses the first configured grouped endpoint URL when reading a shared field', () => {
+    const components = createComponents()
+    const monoRepoField = getEndpointFieldsForTemplate('mono-repo').find(
+      field => field.key === 'AASEnvironment',
+    )
+
+    components.SubmodelRepo.url = 'https://aas-env.example'
+
+    expect(monoRepoField).toBeDefined()
+    expect(getEndpointFieldValue(components, monoRepoField!)).toBe('https://aas-env.example')
   })
 
   it('counts configured grouped endpoints in summaries', () => {

--- a/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
+++ b/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest'
 import {
   BASYX_COMPONENT_KEYS,
   getActiveComponentKeys,
+  getActiveComponentUrlForTemplate,
   getDefaultAasUploadMode,
   getEndpointFieldsForTemplate,
   getEndpointFieldValue,
@@ -93,6 +94,17 @@ describe('InfrastructureUtils.ts', () => {
     expect(getActiveComponentKeys('identifiable')).toEqual(['AASRepo'])
     expect(usesSubmodelSuperpath('identifiable')).toBe(true)
     expect(usesSubmodelSuperpath('full')).toBe(false)
+  })
+
+  it('ignores stale inactive component URLs for a selected template', () => {
+    const infrastructure = createInfrastructure('identifiable')
+    infrastructure.components.AASRepo.url = '  https://aas-repo.example  '
+    infrastructure.components.SubmodelRepo.url = 'https://stale-sm-repo.example'
+    infrastructure.components.AASRegistry.url = 'https://stale-aas-registry.example'
+
+    expect(getActiveComponentUrlForTemplate(infrastructure, 'AASRepo')).toBe('https://aas-repo.example')
+    expect(getActiveComponentUrlForTemplate(infrastructure, 'SubmodelRepo')).toBe('')
+    expect(getActiveComponentUrlForTemplate(infrastructure, 'AASRegistry')).toBe('')
   })
 
   it('defaults server-side upload only for mono templates', () => {

--- a/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
+++ b/aas-web-ui/tests/utils/InfrastructureUtils.test.ts
@@ -1,0 +1,92 @@
+import type { BaSyxComponentKey } from '@/types/BaSyx'
+import type { ComponentConfig, InfrastructureConfig, InfrastructureTemplate } from '@/types/Infrastructure'
+import { describe, expect, it } from 'vitest'
+import {
+  BASYX_COMPONENT_KEYS,
+  getActiveComponentKeys,
+  getDefaultAasUploadMode,
+  getEndpointFieldsForTemplate,
+  getInfrastructureSummary,
+  normalizeInfrastructureTemplate,
+  setEndpointFieldValue,
+  usesSubmodelSuperpath,
+} from '@/utils/InfrastructureUtils'
+
+function createComponents (): Record<BaSyxComponentKey, ComponentConfig> {
+  return {
+    AASDiscovery: { url: '' },
+    AASRegistry: { url: '' },
+    SubmodelRegistry: { url: '' },
+    AASRepo: { url: '' },
+    SubmodelRepo: { url: '' },
+    ConceptDescriptionRepo: { url: '' },
+  }
+}
+
+function createInfrastructure (template: InfrastructureTemplate): InfrastructureConfig {
+  return {
+    id: 'infra-1',
+    name: 'Test Infrastructure',
+    template,
+    components: createComponents(),
+    auth: { securityType: 'No Authentication' },
+  }
+}
+
+describe('InfrastructureUtils.ts', () => {
+  it('defaults unknown template values to full', () => {
+    expect(normalizeInfrastructureTemplate(undefined)).toBe('full')
+    expect(normalizeInfrastructureTemplate('unknown')).toBe('full')
+    expect(normalizeInfrastructureTemplate('catena-x')).toBe('catena-x')
+  })
+
+  it('returns active endpoint fields per template', () => {
+    expect(getEndpointFieldsForTemplate('full').map(field => field.key)).toEqual(BASYX_COMPONENT_KEYS)
+    expect(getEndpointFieldsForTemplate('identifiable').map(field => field.key)).toEqual(['AASRepo'])
+    expect(getEndpointFieldsForTemplate('mono-repo').map(field => field.key)).toEqual([
+      'AASDiscovery',
+      'AASRegistry',
+      'SubmodelRegistry',
+      'AASEnvironment',
+    ])
+    expect(getEndpointFieldsForTemplate('catena-x').map(field => field.key)).toEqual([
+      'DigitalTwinRegistry',
+      'SubmodelService',
+    ])
+  })
+
+  it('maps grouped endpoint URLs into compatibility component slots', () => {
+    const components = createComponents()
+    const monoAllField = getEndpointFieldsForTemplate('mono-all')[0]
+
+    setEndpointFieldValue(components, monoAllField, 'https://aas-env.example')
+
+    expect(BASYX_COMPONENT_KEYS.every(key => components[key].url === 'https://aas-env.example')).toBe(true)
+  })
+
+  it('counts configured grouped endpoints in summaries', () => {
+    const monoAllInfrastructure = createInfrastructure('mono-all')
+    monoAllInfrastructure.components.AASRegistry.url = 'https://aas-env.example'
+
+    const catenaXInfrastructure = createInfrastructure('catena-x')
+    catenaXInfrastructure.components.AASDiscovery.url = 'https://dtr.example'
+
+    expect(getInfrastructureSummary(monoAllInfrastructure)).toBe('1 of 1 endpoints configured')
+    expect(getInfrastructureSummary(catenaXInfrastructure)).toBe('1 of 2 endpoints configured')
+  })
+
+  it('exposes active component capabilities for identifiable superpath use', () => {
+    expect(getActiveComponentKeys('identifiable')).toEqual(['AASRepo'])
+    expect(usesSubmodelSuperpath('identifiable')).toBe(true)
+    expect(usesSubmodelSuperpath('full')).toBe(false)
+  })
+
+  it('defaults server-side upload only for mono templates', () => {
+    expect(getDefaultAasUploadMode('mono-repo')).toBe('server')
+    expect(getDefaultAasUploadMode('mono-all')).toBe('server')
+    expect(getDefaultAasUploadMode('full')).toBe('client')
+    expect(getDefaultAasUploadMode('identifiable')).toBe('client')
+    expect(getDefaultAasUploadMode('catena-x')).toBe('client')
+    expect(getDefaultAasUploadMode(undefined)).toBe('client')
+  })
+})

--- a/examples/CombinedExample/basyx-infra.yml
+++ b/examples/CombinedExample/basyx-infra.yml
@@ -3,6 +3,7 @@ infrastructures:
 
   infra1:
     name: Secured BaSyx
+    template: mono-repo
     components:
       aasDiscovery:
         baseUrl: "http://discovery.basyx.localhost"
@@ -10,11 +11,7 @@ infrastructures:
         baseUrl: "http://aasreg.basyx.localhost"
       submodelRegistry:
         baseUrl: "http://smreg.basyx.localhost"
-      aasRepository:
-        baseUrl: "http://aasenv.basyx.localhost"
-      submodelRepository:
-        baseUrl: "http://aasenv.basyx.localhost"
-      conceptDescriptionRepository:
+      aasEnvironment:
         baseUrl: "http://aasenv.basyx.localhost"
     security:
       type: oauth2
@@ -25,6 +22,7 @@ infrastructures:
 
   infra2:
     name: Local BaSyx
+    template: mono-repo
     components:
       aasDiscovery:
         baseUrl: "http://localhost:9084"
@@ -32,11 +30,7 @@ infrastructures:
         baseUrl: "http://localhost:9082"
       submodelRegistry:
         baseUrl: "http://localhost:9083"
-      aasRepository:
-        baseUrl: "http://localhost:9081"
-      submodelRepository:
-        baseUrl: "http://localhost:9081"
-      conceptDescriptionRepository:
+      aasEnvironment:
         baseUrl: "http://localhost:9081"
     security:
-      type: none 
+      type: none

--- a/examples/MultiInfrastructure/basyx-infra.yml
+++ b/examples/MultiInfrastructure/basyx-infra.yml
@@ -3,6 +3,7 @@ infrastructures:
 
   infra1:
     name: Secured BaSyx
+    template: mono-repo
     components:
       aasDiscovery:
         baseUrl: "http://discovery.basyx.localhost"
@@ -10,11 +11,7 @@ infrastructures:
         baseUrl: "http://aasreg.basyx.localhost"
       submodelRegistry:
         baseUrl: "http://smreg.basyx.localhost"
-      aasRepository:
-        baseUrl: "http://aasenv.basyx.localhost"
-      submodelRepository:
-        baseUrl: "http://aasenv.basyx.localhost"
-      conceptDescriptionRepository:
+      aasEnvironment:
         baseUrl: "http://aasenv.basyx.localhost"
     security:
       type: oauth2
@@ -25,6 +22,7 @@ infrastructures:
 
   infra2:
     name: Local BaSyx
+    template: mono-repo
     components:
       aasDiscovery:
         baseUrl: "http://localhost:9084"
@@ -32,11 +30,7 @@ infrastructures:
         baseUrl: "http://localhost:9082"
       submodelRegistry:
         baseUrl: "http://localhost:9083"
-      aasRepository:
-        baseUrl: "http://localhost:9081"
-      submodelRepository:
-        baseUrl: "http://localhost:9081"
-      conceptDescriptionRepository:
+      aasEnvironment:
         baseUrl: "http://localhost:9081"
     security:
-      type: none 
+      type: none


### PR DESCRIPTION
This pull request introduces infrastructure template support to the BaSyx UI configuration and refactors component configuration to be template-aware. The main changes include adding infrastructure templates to the configuration file and UI, updating component configuration panels to adapt to the selected template, and improving logic for component integration and endpoint management. Additionally, several bug fixes and code improvements were made in AAS list and deletion logic.

**Infrastructure Template Support**

* Added infrastructure template definitions and documentation to `basyx-infra.yml`, with template assignments for each infrastructure (`full`, `mono-repo`, `mono-all`, `catena-x`, `identifiable`). [[1]](diffhunk://#diff-356d238c4fb0dcf6c1a0f0f66722039dd4e3a4fab621b7339c074973ea7a9f27R14-R19) [[2]](diffhunk://#diff-356d238c4fb0dcf6c1a0f0f66722039dd4e3a4fab621b7339c074973ea7a9f27R28) [[3]](diffhunk://#diff-356d238c4fb0dcf6c1a0f0f66722039dd4e3a4fab621b7339c074973ea7a9f27R51) [[4]](diffhunk://#diff-356d238c4fb0dcf6c1a0f0f66722039dd4e3a4fab621b7339c074973ea7a9f27R78-R86) [[5]](diffhunk://#diff-356d238c4fb0dcf6c1a0f0f66722039dd4e3a4fab621b7339c074973ea7a9f27R100-R105) [[6]](diffhunk://#diff-356d238c4fb0dcf6c1a0f0f66722039dd4e3a4fab621b7339c074973ea7a9f27R115-L129)
* Updated the infrastructure management UI to allow selecting templates, display template descriptions, and show template labels in the infrastructure list. [[1]](diffhunk://#diff-11b45c252d2d50d8743fdfa4bfe7e401f30ce01563aac36432f52c869eebf075R86-R121) [[2]](diffhunk://#diff-11b45c252d2d50d8743fdfa4bfe7e401f30ce01563aac36432f52c869eebf075L222-R257) [[3]](diffhunk://#diff-3d38b590c66ac3ab8d0f6fa789a38007ceba36bad0ba9a3cc2eb8568472e092eR37-R40) [[4]](diffhunk://#diff-3d38b590c66ac3ab8d0f6fa789a38007ceba36bad0ba9a3cc2eb8568472e092eL78-R81)

**Component Configuration Refactoring**

* Refactored `ComponentConfigPanel.vue` to dynamically render endpoint fields and integration options based on the selected template, improving maintainability and flexibility. [[1]](diffhunk://#diff-5350c8891cd9e16c22ee46131f1283b9ecefd972cd7b76432da71282854914ffL3-R33) [[2]](diffhunk://#diff-5350c8891cd9e16c22ee46131f1283b9ecefd972cd7b76432da71282854914ffL42-R61) [[3]](diffhunk://#diff-5350c8891cd9e16c22ee46131f1283b9ecefd972cd7b76432da71282854914ffR75) [[4]](diffhunk://#diff-5350c8891cd9e16c22ee46131f1283b9ecefd972cd7b76432da71282854914ffR86-R155)
* Updated event handling and status logic to work with template-driven fields and multiple component keys.

**AAS List and Deletion Logic Improvements**

* Improved watcher behavior in `AASList.vue` to better handle infrastructure switching and pagination reset, and fixed reload triggers. [[1]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL526-R527) [[2]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL543-R544) [[3]](diffhunk://#diff-a66fd49c886af99aa3c3126e3f06fed68980e7ad4e70ad47ec57ed5d24220dcaL599-L612)
* Enhanced integration logic in `DeleteAAS.vue` to correctly determine when registry/discovery integrations are active based on the template, and fixed submodel fetch and delete calls to include the parent AAS id. [[1]](diffhunk://#diff-7404e76454c88004724fc99322ca82c509e0a9a444220211c0c680807e6087eeR65) [[2]](diffhunk://#diff-7404e76454c88004724fc99322ca82c509e0a9a444220211c0c680807e6087eeR100-R123) [[3]](diffhunk://#diff-7404e76454c88004724fc99322ca82c509e0a9a444220211c0c680807e6087eeL122-R139) [[4]](diffhunk://#diff-7404e76454c88004724fc99322ca82c509e0a9a444220211c0c680807e6087eeL151-R168)

These changes together make the infrastructure configuration more robust, flexible, and easier to manage for different deployment scenarios.