### PR TITLE
Improve business partner management in CatenaXplorer

### DIFF
--- a/Docs/CatenaXEdcBffDevelopment.md
+++ b/Docs/CatenaXEdcBffDevelopment.md
@@ -106,7 +106,9 @@ CX_EDC_BFF_UPSTREAM_URL=http://localhost:3002 pnpm dev
 
 The UI calls `/api/catena-x/edc/...`; Vite proxies those requests to the local BFF.
 
-Open the UI, select the Catena-X infrastructure, open CatenaXplorer, choose a counterparty, and load descriptors through the descriptor search.
+Open the UI, select the Catena-X infrastructure, and open CatenaXplorer. Choose a configured business partner or select **Use another partner…** and enter its counterparty ID and DSP address. Select **Load descriptors** to make the EDC request; changing the selection alone deliberately sends no request.
+
+With editable endpoint configuration enabled, use **Settings → Manage Infrastructures** to manage multiple partners and their default. A successfully loaded runtime partner also offers **Save partner** in CatenaXplorer. Partner details are browser-local configuration, while Management API credentials and `CX_EDC_ALLOWED_COUNTER_PARTY_ADDRESSES` remain server-side.
 
 ## 4. Smoke Test Without a Real EDC
 

--- a/aas-web-ui/src/components.d.ts
+++ b/aas-web-ui/src/components.d.ts
@@ -32,6 +32,7 @@ declare module 'vue' {
     CarbonFootprint_v0_9: typeof import('./components/Plugins/Submodels/CarbonFootprint_v0_9.vue')['default']
     CarbonFootprint_v1_0: typeof import('./components/Plugins/Submodels/CarbonFootprint_v1_0.vue')['default']
     CatenaXEdcConfigPanel: typeof import('./components/AppNavigation/Settings/CatenaXEdcConfigPanel.vue')['default']
+    CatenaXPartnerDialog: typeof import('./components/AppNavigation/Settings/CatenaXPartnerDialog.vue')['default']
     CollectionForm: typeof import('./components/EditorComponents/SubmodelElements/CollectionForm.vue')['default']
     CommandPalette: typeof import('./components/AppNavigation/CommandPalette.vue')['default']
     ComponentConfigPanel: typeof import('./components/AppNavigation/Settings/ComponentConfigPanel.vue')['default']

--- a/aas-web-ui/src/components/AppNavigation/Settings/CatenaXEdcConfigPanel.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/CatenaXEdcConfigPanel.vue
@@ -4,57 +4,169 @@
       class="mb-3"
       density="compact"
       icon="mdi-shield-key-outline"
-      text="Only the proxy ID and UI defaults are stored here. The EDC Management API URL and API key must be configured on the server-side proxy."
+      text="Partner details are stored in this browser. Management API credentials and the allowed DSP address list remain server-side."
       type="info"
       variant="tonal"
     />
 
-    <v-row density="compact">
-      <v-col cols="12" md="4">
-        <v-text-field
-          v-model="proxyIdModel"
-          autocomplete="off"
-          bg-color="surface-light"
-          density="compact"
-          flat
-          label="EDC Proxy ID"
-          placeholder="default"
-          variant="outlined"
-        />
-      </v-col>
+    <v-text-field
+      v-model="proxyIdModel"
+      autocomplete="off"
+      bg-color="surface-light"
+      density="compact"
+      flat
+      label="EDC Proxy ID"
+      placeholder="default"
+      variant="outlined"
+    />
 
-      <v-col cols="12" md="4">
-        <v-text-field
-          v-model="counterPartyIdModel"
-          autocomplete="off"
-          bg-color="surface-light"
-          density="compact"
-          flat
-          label="Default Counterparty ID"
-          placeholder="Counterparty ID"
-          variant="outlined"
-        />
-      </v-col>
+    <div class="d-flex align-center mt-2 mb-2">
+      <div>
+        <div class="text-subtitle-1 font-weight-medium">Business partners</div>
 
-      <v-col cols="12" md="4">
-        <v-text-field
-          v-model="counterPartyAddressModel"
-          autocomplete="url"
-          bg-color="surface-light"
-          density="compact"
-          flat
-          label="Default Counterparty DSP Address"
-          placeholder="https://<counterparty-dsp-endpoint>"
-          variant="outlined"
-        />
-      </v-col>
-    </v-row>
+        <div class="text-body-small text-medium-emphasis">
+          Choose the default provider used when CatenaXplorer opens.
+        </div>
+      </div>
+    </div>
+
+    <v-alert
+      v-if="partners.length === 0"
+      class="mb-3"
+      density="compact"
+      text="No partners configured. Add one here or use another partner directly in CatenaXplorer."
+      type="info"
+      variant="outlined"
+    />
+
+    <v-radio-group
+      v-else
+      v-model="defaultPartnerIdModel"
+      class="mb-0"
+      hide-details
+    >
+      <v-list border class="rounded-lg pa-0" lines="three">
+        <template v-for="(partner, index) in partners" :key="partner.id">
+          <v-list-item
+            :aria-label="`Use ${partner.name || partner.counterPartyId} as default partner`"
+            class="py-2"
+            @click="defaultPartnerIdModel = partner.id"
+          >
+            <template #prepend>
+              <v-radio
+                :aria-label="`Use ${partner.name || partner.counterPartyId} as default`"
+                :value="partner.id"
+                @click.stop
+              />
+            </template>
+
+            <v-list-item-title class="d-flex align-center flex-wrap ga-2">
+              <span>{{ partner.name || partner.counterPartyId }}</span>
+
+              <v-chip
+                v-if="partner.id === defaultPartnerIdModel"
+                color="primary"
+                size="x-small"
+              >
+                Default
+              </v-chip>
+            </v-list-item-title>
+
+            <v-list-item-subtitle class="text-break opacity-100">
+              {{ partner.counterPartyId }}
+            </v-list-item-subtitle>
+
+            <v-list-item-subtitle class="text-break">
+              {{ partner.counterPartyAddress }}
+            </v-list-item-subtitle>
+
+            <template #append>
+              <v-tooltip text="Edit partner">
+                <template #activator="{ props: tooltipProps }">
+                  <v-btn
+                    v-bind="tooltipProps"
+                    :aria-label="`Edit ${partner.name || partner.counterPartyId}`"
+                    icon="mdi-pencil-outline"
+                    size="small"
+                    variant="text"
+                    @click.stop="openEditPartner(partner)"
+                  />
+                </template>
+              </v-tooltip>
+
+              <v-tooltip text="Delete partner">
+                <template #activator="{ props: tooltipProps }">
+                  <v-btn
+                    v-bind="tooltipProps"
+                    :aria-label="`Delete ${partner.name || partner.counterPartyId}`"
+                    icon="mdi-delete-outline"
+                    size="small"
+                    variant="text"
+                    @click.stop="requestPartnerDelete(partner)"
+                  />
+                </template>
+              </v-tooltip>
+            </template>
+          </v-list-item>
+
+          <v-divider v-if="index < partners.length - 1" />
+        </template>
+      </v-list>
+    </v-radio-group>
+
+    <v-btn
+      block
+      class="mt-3 text-buttonText"
+      color="primary"
+      prepend-icon="mdi-plus"
+      text="Add business partner"
+      variant="flat"
+      @click="openAddPartner"
+    />
+
+    <CatenaXPartnerDialog
+      v-model="partnerDialogOpen"
+      :allow-default="!partnerToEdit"
+      :default-partner-id="defaultPartnerIdModel"
+      :existing-partners="partners"
+      :partner="partnerToEdit"
+      :title="partnerToEdit ? 'Edit business partner' : 'Add business partner'"
+      @save="savePartner"
+    />
+
+    <v-dialog v-model="deleteDialogOpen" max-width="480">
+      <v-card rounded="lg">
+        <v-card-title>Delete business partner?</v-card-title>
+
+        <v-card-text>
+          <div>
+            Remove “{{ partnerToDelete?.name || partnerToDelete?.counterPartyId }}” from this infrastructure?
+          </div>
+
+          <div v-if="replacementDefaultPartner" class="mt-2 text-medium-emphasis">
+            “{{ replacementDefaultPartner.name || replacementDefaultPartner.counterPartyId }}” will become the default partner.
+          </div>
+
+          <div v-else-if="deletingFinalDefaultPartner" class="mt-2 text-medium-emphasis">
+            No default partner will remain.
+          </div>
+        </v-card-text>
+
+        <v-card-actions>
+          <v-spacer />
+          <v-btn text="Cancel" @click="deleteDialogOpen = false" />
+          <v-btn color="error" text="Delete" variant="flat" @click="deletePartner" />
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
   </v-container>
 </template>
 
 <script lang="ts" setup>
-  import type { CatenaXConfig } from '@/types/Infrastructure'
-  import { computed } from 'vue'
+  import type { CatenaXConfig, CatenaXPartner } from '@/types/Infrastructure'
+  import { computed, ref } from 'vue'
+  import CatenaXPartnerDialog from '@/components/AppNavigation/Settings/CatenaXPartnerDialog.vue'
+  import { normalizeCatenaXPartners } from '@/utils/CatenaXPartnerUtils'
 
   const props = defineProps<{
     modelValue?: CatenaXConfig
@@ -64,77 +176,90 @@
     'update:model-value': [value: CatenaXConfig | undefined]
   }>()
 
+  const partnerDialogOpen = ref(false)
+  const deleteDialogOpen = ref(false)
+  const partnerToEdit = ref<CatenaXPartner | null>(null)
+  const partnerToDelete = ref<CatenaXPartner | null>(null)
+
+  const partners = computed(() => normalizeCatenaXPartners(props.modelValue?.edc?.partners ?? []))
   const proxyIdModel = computed({
     get: () => props.modelValue?.edc?.proxyId ?? '',
-    set: value => updateEdcConfig({ proxyId: value }),
+    set: value => emitEdcConfig(partners.value, defaultPartnerIdModel.value, value),
   })
-
-  const counterPartyIdModel = computed({
-    get: () => props.modelValue?.edc?.defaultCounterPartyId ?? '',
-    set: value => updateEdcConfig({ defaultCounterPartyId: value }),
+  const defaultPartnerIdModel = computed({
+    get: () => props.modelValue?.edc?.defaultPartnerId ?? partners.value[0]?.id ?? '',
+    set: value => emitEdcConfig(partners.value, value),
   })
-
-  const counterPartyAddressModel = computed({
-    get: () => props.modelValue?.edc?.defaultCounterPartyAddress ?? '',
-    set: value => updateEdcConfig({ defaultCounterPartyAddress: value }),
-  })
-
-  function updateEdcConfig (
-    patch: Partial<NonNullable<CatenaXConfig['edc']>>,
-  ): void {
-    const edc = {
-      proxyId: props.modelValue?.edc?.proxyId ?? '',
-      defaultCounterPartyId: props.modelValue?.edc?.defaultCounterPartyId,
-      defaultCounterPartyAddress: props.modelValue?.edc?.defaultCounterPartyAddress,
-      ...patch,
+  const replacementDefaultPartner = computed(() => {
+    if (!partnerToDelete.value || partnerToDelete.value.id !== defaultPartnerIdModel.value) {
+      return null
     }
 
-    if (edc.proxyId.trim() === '') {
-      emit('update:model-value', { accessMode: props.modelValue?.accessMode ?? 'edc' })
+    return partners.value.find(partner => partner.id !== partnerToDelete.value!.id) ?? null
+  })
+  const deletingFinalDefaultPartner = computed(() => {
+    if (!partnerToDelete.value || partnerToDelete.value.id !== defaultPartnerIdModel.value) {
+      return false
+    }
+
+    return partners.value.length === 1
+  })
+
+  function openAddPartner (): void {
+    partnerToEdit.value = null
+    partnerDialogOpen.value = true
+  }
+
+  function openEditPartner (partner: CatenaXPartner): void {
+    partnerToEdit.value = partner
+    partnerDialogOpen.value = true
+  }
+
+  function savePartner (partner: CatenaXPartner, useAsDefault: boolean): void {
+    const updatedPartners = [
+      ...partners.value.filter(existingPartner => existingPartner.id !== partner.id),
+      partner,
+    ]
+    const defaultPartnerId = useAsDefault || defaultPartnerIdModel.value === ''
+      ? partner.id
+      : defaultPartnerIdModel.value
+    emitEdcConfig(updatedPartners, defaultPartnerId)
+  }
+
+  function requestPartnerDelete (partner: CatenaXPartner): void {
+    partnerToDelete.value = partner
+    deleteDialogOpen.value = true
+  }
+
+  function deletePartner (): void {
+    if (!partnerToDelete.value) {
       return
     }
 
+    const updatedPartners = partners.value.filter(partner => partner.id !== partnerToDelete.value!.id)
+    const defaultPartnerId = partnerToDelete.value.id === defaultPartnerIdModel.value
+      ? updatedPartners[0]?.id ?? ''
+      : defaultPartnerIdModel.value
+    emitEdcConfig(updatedPartners, defaultPartnerId)
+    partnerToDelete.value = null
+    deleteDialogOpen.value = false
+  }
+
+  function emitEdcConfig (
+    updatedPartners: CatenaXPartner[],
+    defaultPartnerId: string,
+    proxyId = proxyIdModel.value,
+  ): void {
+    const defaultPartner = updatedPartners.find(partner => partner.id === defaultPartnerId)
     emit('update:model-value', {
       accessMode: props.modelValue?.accessMode ?? 'edc',
       edc: {
-        proxyId: edc.proxyId,
-        defaultCounterPartyId: edc.defaultCounterPartyId || undefined,
-        defaultCounterPartyAddress: edc.defaultCounterPartyAddress || undefined,
-        defaultPartnerId: props.modelValue?.edc?.defaultPartnerId,
-        partners: buildPartners(edc.defaultCounterPartyId, edc.defaultCounterPartyAddress),
+        proxyId,
+        defaultPartnerId: defaultPartner?.id,
+        defaultCounterPartyId: defaultPartner?.counterPartyId,
+        defaultCounterPartyAddress: defaultPartner?.counterPartyAddress,
+        partners: updatedPartners.length > 0 ? updatedPartners : undefined,
       },
     })
-  }
-
-  function buildPartners (
-    counterPartyId?: string,
-    counterPartyAddress?: string,
-  ): NonNullable<CatenaXConfig['edc']>['partners'] | undefined {
-    const normalizedCounterPartyId = counterPartyId?.trim() ?? ''
-    const normalizedCounterPartyAddress = counterPartyAddress?.trim() ?? ''
-    const existingPartners = props.modelValue?.edc?.partners ?? []
-    if (normalizedCounterPartyId === '' || normalizedCounterPartyAddress === '') {
-      return existingPartners.length > 0 ? existingPartners : undefined
-    }
-
-    const partner = {
-      id: props.modelValue?.edc?.defaultPartnerId
-        ?? `${normalizedCounterPartyId}-${normalizedCounterPartyAddress}`
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-|-$/g, ''),
-      counterPartyId: normalizedCounterPartyId,
-      counterPartyAddress: normalizedCounterPartyAddress,
-    }
-
-    const partners = [
-      partner,
-      ...existingPartners.filter(existingPartner =>
-        existingPartner.counterPartyId !== normalizedCounterPartyId
-        || existingPartner.counterPartyAddress !== normalizedCounterPartyAddress,
-      ),
-    ]
-
-    return partners
   }
 </script>

--- a/aas-web-ui/src/components/AppNavigation/Settings/CatenaXPartnerDialog.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/CatenaXPartnerDialog.vue
@@ -1,0 +1,174 @@
+<template>
+  <v-dialog v-model="dialogOpen" max-width="640" persistent>
+    <v-card rounded="lg">
+      <v-card-title>{{ title }}</v-card-title>
+      <v-divider />
+
+      <v-card-text class="pt-4">
+        <v-form ref="formRef" @submit.prevent="savePartner">
+          <v-text-field
+            v-model="name"
+            autocomplete="organization"
+            bg-color="surface-light"
+            density="compact"
+            label="Display name (optional)"
+            placeholder="Defaults to the counterparty ID"
+            variant="outlined"
+          />
+
+          <v-text-field
+            v-model="counterPartyId"
+            autocomplete="off"
+            bg-color="surface-light"
+            density="compact"
+            label="Counterparty ID"
+            :rules="[requiredRule]"
+            variant="outlined"
+          />
+
+          <v-text-field
+            v-model="counterPartyAddress"
+            autocomplete="url"
+            bg-color="surface-light"
+            density="compact"
+            :error-messages="duplicateError"
+            hint="HTTP addresses require the server-side insecure-address option."
+            label="Counterparty DSP Address"
+            persistent-hint
+            placeholder="https://partner.example/api/v1/dsp"
+            :rules="[requiredRule, addressRule]"
+            variant="outlined"
+          />
+
+          <v-checkbox
+            v-if="allowDefault"
+            v-model="useAsDefault"
+            color="primary"
+            hide-details
+            label="Use as default partner"
+          />
+        </v-form>
+      </v-card-text>
+
+      <v-divider />
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn text="Cancel" @click="close" />
+
+        <v-btn
+          class="text-buttonText"
+          color="primary"
+          text="Save partner"
+          variant="flat"
+          @click="savePartner"
+        />
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts" setup>
+  import type { CatenaXPartner } from '@/types/Infrastructure'
+  import { ref, watch } from 'vue'
+  import {
+    createCatenaXPartnerId,
+    getCatenaXPartnerKey,
+    isValidCatenaXPartnerAddress,
+  } from '@/utils/CatenaXPartnerUtils'
+
+  const props = withDefaults(defineProps<{
+    allowDefault?: boolean
+    defaultPartnerId?: string
+    existingPartners?: CatenaXPartner[]
+    modelValue: boolean
+    partner?: Partial<CatenaXPartner> | null
+    title?: string
+  }>(), {
+    allowDefault: true,
+    defaultPartnerId: '',
+    existingPartners: () => [],
+    partner: null,
+    title: 'Add business partner',
+  })
+
+  const emit = defineEmits<{
+    'save': [partner: CatenaXPartner, useAsDefault: boolean]
+    'update:model-value': [value: boolean]
+  }>()
+
+  const formRef = ref<{ validate: () => Promise<{ valid: boolean }> } | null>(null)
+  const name = ref('')
+  const counterPartyId = ref('')
+  const counterPartyAddress = ref('')
+  const duplicateError = ref('')
+  const useAsDefault = ref(false)
+
+  const dialogOpen = ref(false)
+
+  watch(
+    () => props.modelValue,
+    value => {
+      dialogOpen.value = value
+      if (value) {
+        name.value = props.partner?.name ?? ''
+        counterPartyId.value = props.partner?.counterPartyId ?? ''
+        counterPartyAddress.value = props.partner?.counterPartyAddress ?? ''
+        duplicateError.value = ''
+        useAsDefault.value = Boolean(
+          props.partner?.id && props.partner.id === props.defaultPartnerId,
+        )
+      }
+    },
+    { immediate: true },
+  )
+
+  watch(dialogOpen, value => {
+    if (!value) {
+      emit('update:model-value', false)
+    }
+  })
+
+  const requiredRule = (value: string): boolean | string => value.trim() !== '' || 'This field is required.'
+  function addressRule (value: string): boolean | string {
+    return isValidCatenaXPartnerAddress(value) || 'Enter an absolute HTTP or HTTPS URL.'
+  }
+
+  function close (): void {
+    dialogOpen.value = false
+  }
+
+  async function savePartner (): Promise<void> {
+    duplicateError.value = ''
+    const { valid } = await formRef.value!.validate()
+    if (!valid) {
+      return
+    }
+
+    const normalizedId = counterPartyId.value.trim()
+    const normalizedAddress = counterPartyAddress.value.trim()
+    const candidateKey = getCatenaXPartnerKey({
+      counterPartyId: normalizedId,
+      counterPartyAddress: normalizedAddress,
+    })
+    const duplicate = props.existingPartners.some(partner =>
+      partner.id !== props.partner?.id && getCatenaXPartnerKey(partner) === candidateKey,
+    )
+    if (duplicate) {
+      duplicateError.value = 'This counterparty and DSP address are already configured.'
+      return
+    }
+
+    emit('save', {
+      id: props.partner?.id?.trim() || createCatenaXPartnerId(
+        normalizedId,
+        normalizedAddress,
+        props.existingPartners.map(partner => partner.id),
+      ),
+      name: name.value.trim() || undefined,
+      counterPartyId: normalizedId,
+      counterPartyAddress: normalizedAddress,
+    }, useAsDefault.value)
+    close()
+  }
+</script>

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
@@ -10,6 +10,10 @@ import type {
 import { authenticateOAuth2ClientCredentials } from '@/composables/Auth/OAuth2Auth'
 import { useInfrastructureConfigLoader } from '@/composables/Infrastructure/useInfrastructureConfigLoader'
 import { useNavigationStore } from '@/store/NavigationStore'
+import {
+  createCatenaXPartnerId,
+  normalizeCatenaXPartners,
+} from '@/utils/CatenaXPartnerUtils'
 import { normalizeInfrastructureTemplate } from '@/utils/InfrastructureUtils'
 
 /**
@@ -220,14 +224,16 @@ export function useInfrastructureStorage (): {
       ...(edc?.partners ?? []),
       ...(legacyDefaultPartner ? [legacyDefaultPartner] : []),
     ])
+    const defaultPartnerId = edc?.defaultPartnerId?.trim() || partners[0]?.id
+    const defaultPartner = partners.find(partner => partner.id === defaultPartnerId) ?? partners[0]
 
     infrastructure.catenaX = {
       accessMode: 'edc',
       edc: {
         proxyId,
-        defaultCounterPartyId: edc?.defaultCounterPartyId?.trim() || undefined,
-        defaultCounterPartyAddress: edc?.defaultCounterPartyAddress?.trim() || undefined,
-        defaultPartnerId: edc?.defaultPartnerId?.trim() || partners[0]?.id || undefined,
+        defaultCounterPartyId: defaultPartner?.counterPartyId,
+        defaultCounterPartyAddress: defaultPartner?.counterPartyAddress,
+        defaultPartnerId: defaultPartner?.id,
         partners: partners.length > 0 ? partners : undefined,
       },
     }
@@ -242,32 +248,6 @@ export function useInfrastructureStorage (): {
     return infrastructure.catenaX?.edc?.proxyId?.trim() ? 'edc' : 'direct'
   }
 
-  function normalizeCatenaXPartners (partners: CatenaXPartner[]): CatenaXPartner[] {
-    const uniquePartners = new Map<string, CatenaXPartner>()
-
-    for (const partner of partners) {
-      const counterPartyId = partner.counterPartyId?.trim() ?? ''
-      const counterPartyAddress = partner.counterPartyAddress?.trim() ?? ''
-      if (counterPartyId === '' || counterPartyAddress === '') {
-        continue
-      }
-
-      const id = partner.id?.trim() || createPartnerId(counterPartyId, counterPartyAddress)
-      if (id === '') {
-        continue
-      }
-
-      uniquePartners.set(`${counterPartyId}::${counterPartyAddress}`, {
-        id,
-        name: partner.name?.trim() || undefined,
-        counterPartyId,
-        counterPartyAddress,
-      })
-    }
-
-    return Array.from(uniquePartners.values())
-  }
-
   function createLegacyDefaultPartner (
     counterPartyId: string | undefined,
     counterPartyAddress: string | undefined,
@@ -279,17 +259,10 @@ export function useInfrastructureStorage (): {
     }
 
     return {
-      id: createPartnerId(normalizedCounterPartyId, normalizedCounterPartyAddress),
+      id: createCatenaXPartnerId(normalizedCounterPartyId, normalizedCounterPartyAddress),
       counterPartyId: normalizedCounterPartyId,
       counterPartyAddress: normalizedCounterPartyAddress,
     }
-  }
-
-  function createPartnerId (counterPartyId: string, counterPartyAddress: string): string {
-    return `${counterPartyId}-${counterPartyAddress}`
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '')
   }
 
   /**

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureYamlParser.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureYamlParser.ts
@@ -10,6 +10,7 @@ import type {
   YamlInfrastructuresConfig,
   YamlSecurityConfig,
 } from '@/types/Infrastructure'
+import { createCatenaXPartnerId } from '@/utils/CatenaXPartnerUtils'
 import {
   getEndpointFieldsForTemplate,
   normalizeInfrastructureTemplate,
@@ -153,6 +154,9 @@ export function useInfrastructureYamlParser (): {
     const accessMode = normalizeCatenaXAccessMode(yamlConfig.catenaX?.accessMode)
     const proxyId = yamlConfig.catenaX?.edc?.proxyId?.trim()
     const uniquePartners = parseCatenaXPartners(yamlConfig)
+    const requestedDefaultPartnerId = yamlConfig.catenaX?.edc?.defaultPartnerId?.trim()
+    const defaultPartner = uniquePartners.find(partner => partner.id === requestedDefaultPartnerId)
+      ?? uniquePartners[0]
 
     if (accessMode === 'direct') {
       return { accessMode }
@@ -166,11 +170,9 @@ export function useInfrastructureYamlParser (): {
       accessMode: 'edc',
       edc: {
         proxyId,
-        defaultCounterPartyId: yamlConfig.catenaX?.edc?.defaultCounterPartyId?.trim() || undefined,
-        defaultCounterPartyAddress: yamlConfig.catenaX?.edc?.defaultCounterPartyAddress?.trim() || undefined,
-        defaultPartnerId: yamlConfig.catenaX?.edc?.defaultPartnerId?.trim()
-          || uniquePartners[0]?.id
-          || undefined,
+        defaultCounterPartyId: defaultPartner?.counterPartyId,
+        defaultCounterPartyAddress: defaultPartner?.counterPartyAddress,
+        defaultPartnerId: defaultPartner?.id,
         partners: uniquePartners.length > 0 ? uniquePartners : undefined,
       },
     }
@@ -183,7 +185,7 @@ export function useInfrastructureYamlParser (): {
   function parseCatenaXPartners (yamlConfig: YamlInfrastructureConfig): CatenaXPartner[] {
     const partners = yamlConfig.catenaX?.edc?.partners
       ?.map(partner => ({
-        id: partner.id?.trim() || createPartnerId(partner.counterPartyId, partner.counterPartyAddress),
+        id: partner.id?.trim() || createCatenaXPartnerId(partner.counterPartyId ?? '', partner.counterPartyAddress ?? ''),
         name: partner.name?.trim() || undefined,
         counterPartyId: partner.counterPartyId?.trim() ?? '',
         counterPartyAddress: partner.counterPartyAddress?.trim() ?? '',
@@ -214,19 +216,10 @@ export function useInfrastructureYamlParser (): {
     }
 
     return {
-      id: createPartnerId(normalizedCounterPartyId, normalizedCounterPartyAddress),
+      id: createCatenaXPartnerId(normalizedCounterPartyId, normalizedCounterPartyAddress),
       counterPartyId: normalizedCounterPartyId,
       counterPartyAddress: normalizedCounterPartyAddress,
     }
-  }
-
-  function createPartnerId (counterPartyId: string | undefined, counterPartyAddress: string | undefined): string {
-    const rawId = `${counterPartyId?.trim() ?? ''}-${counterPartyAddress?.trim() ?? ''}`
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '')
-
-    return rawId || ''
   }
 
   /**

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/catenaXplorerPartners.ts
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/catenaXplorerPartners.ts
@@ -1,33 +1,12 @@
 import type { CatenaXPartner } from '@/types/Infrastructure'
+import {
+  getCatenaXPartnerKey,
+  normalizeCatenaXPartner,
+  normalizeCatenaXPartners,
+} from '@/utils/CatenaXPartnerUtils'
 
 const storageKeyPrefix = 'catenaXplorerRecentPartners:'
 const maxRecentPartners = 8
-
-function normalizeText (value: unknown): string {
-  return typeof value === 'string' ? value.trim() : ''
-}
-
-function createPartnerId (counterPartyId: string, counterPartyAddress: string): string {
-  return `${counterPartyId}-${counterPartyAddress}`
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-}
-
-function normalizePartner (partner: Partial<CatenaXPartner>): CatenaXPartner | null {
-  const counterPartyId = normalizeText(partner.counterPartyId)
-  const counterPartyAddress = normalizeText(partner.counterPartyAddress)
-  if (counterPartyId === '' || counterPartyAddress === '') {
-    return null
-  }
-
-  return {
-    id: normalizeText(partner.id) || createPartnerId(counterPartyId, counterPartyAddress),
-    name: normalizeText(partner.name) || undefined,
-    counterPartyId,
-    counterPartyAddress,
-  }
-}
 
 function getStorageKey (proxyId: string): string {
   return `${storageKeyPrefix}${proxyId.trim()}`
@@ -58,26 +37,7 @@ function writeRecentPartnersToStorage (proxyId: string, partners: CatenaXPartner
   window.localStorage.setItem(getStorageKey(proxyId), JSON.stringify(partners.slice(0, maxRecentPartners)))
 }
 
-export function normalizePartners (partners: unknown): CatenaXPartner[] {
-  if (!Array.isArray(partners)) {
-    return []
-  }
-
-  const uniquePartners = new Map<string, CatenaXPartner>()
-  for (const partner of partners) {
-    const normalizedPartner = normalizePartner(partner as Partial<CatenaXPartner>)
-    if (!normalizedPartner) {
-      continue
-    }
-
-    uniquePartners.set(
-      `${normalizedPartner.counterPartyId}::${normalizedPartner.counterPartyAddress}`,
-      normalizedPartner,
-    )
-  }
-
-  return Array.from(uniquePartners.values())
-}
+export const normalizePartners = normalizeCatenaXPartners
 
 export function getRecentCatenaXPartners (proxyId: string): CatenaXPartner[] {
   if (proxyId.trim() === '') {
@@ -91,20 +51,32 @@ export function rememberRecentCatenaXPartner (
   proxyId: string,
   partner: Partial<CatenaXPartner>,
 ): CatenaXPartner | null {
-  const normalizedPartner = normalizePartner(partner)
+  const normalizedPartner = normalizeCatenaXPartner(partner)
   if (proxyId.trim() === '' || !normalizedPartner) {
     return null
   }
 
   const existingPartners = readRecentPartnersFromStorage(proxyId)
+  const partnerKey = getCatenaXPartnerKey(normalizedPartner)
   const recentPartners = [
     normalizedPartner,
-    ...existingPartners.filter(existingPartner =>
-      existingPartner.counterPartyId !== normalizedPartner.counterPartyId
-      || existingPartner.counterPartyAddress !== normalizedPartner.counterPartyAddress,
-    ),
+    ...existingPartners.filter(existingPartner => getCatenaXPartnerKey(existingPartner) !== partnerKey),
   ]
 
   writeRecentPartnersToStorage(proxyId, recentPartners)
   return normalizedPartner
+}
+
+export function forgetRecentCatenaXPartner (
+  proxyId: string,
+  partner: Pick<CatenaXPartner, 'counterPartyId' | 'counterPartyAddress'>,
+): void {
+  if (proxyId.trim() === '') {
+    return
+  }
+
+  const partnerKey = getCatenaXPartnerKey(partner)
+  const recentPartners = readRecentPartnersFromStorage(proxyId)
+    .filter(existingPartner => getCatenaXPartnerKey(existingPartner) !== partnerKey)
+  writeRecentPartnersToStorage(proxyId, recentPartners)
 }

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/catenaXplorerUtils.ts
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/catenaXplorerUtils.ts
@@ -101,8 +101,54 @@ export function buildShellDescriptorsCurlCommand (
   dtrUrl: string,
   assetIdName: string,
   assetIdValue: string,
+  authorizationHeader?: string,
 ): string {
-  return `curl -X GET ${quoteShellArgument(buildShellDescriptorsRequestUrl(dtrUrl, assetIdName, assetIdValue))}`
+  return [
+    `curl -X GET ${quoteShellArgument(buildShellDescriptorsRequestUrl(dtrUrl, assetIdName, assetIdValue))}`,
+    ...buildAuthorizationHeaderLine(authorizationHeader),
+  ].join(' \\\n')
+}
+
+export function buildEdcShellDescriptorsCurlCommand (
+  endpointUrl: string,
+  counterPartyId: string,
+  counterPartyAddress: string,
+  protocol: string,
+  assetIdName: string,
+  assetIdValue: string,
+  transferProcessId?: string,
+  authorizationHeader?: string,
+): string {
+  const requestBody: Record<string, unknown> = {
+    counterPartyId: toTrimmedString(counterPartyId),
+    counterPartyAddress: toTrimmedString(counterPartyAddress),
+    protocol: toTrimmedString(protocol),
+    limit: 100,
+  }
+  const name = toTrimmedString(assetIdName)
+  const value = toTrimmedString(assetIdValue)
+  if (name !== '' && value !== '') {
+    requestBody.assetIds = [{ name, value }]
+  }
+
+  const normalizedTransferProcessId = toTrimmedString(transferProcessId)
+  if (normalizedTransferProcessId !== '') {
+    requestBody.transferProcessId = normalizedTransferProcessId
+  }
+
+  return [
+    `curl -X POST ${quoteShellArgument(endpointUrl)}`,
+    `  -H ${quoteShellArgument('Content-Type: application/json')}`,
+    ...buildAuthorizationHeaderLine(authorizationHeader),
+    `  --data-raw ${quoteShellArgument(JSON.stringify(requestBody))}`,
+  ].join(' \\\n')
+}
+
+function buildAuthorizationHeaderLine (authorizationHeader?: string): string[] {
+  const normalizedHeader = toTrimmedString(authorizationHeader)
+  return normalizedHeader === ''
+    ? []
+    : [`  -H ${quoteShellArgument(`Authorization: ${normalizedHeader}`)}`]
 }
 
 export function asArray<T = any> (value: unknown): T[] {

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/components/CatenaXplorerNavigationDrawer.vue
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/components/CatenaXplorerNavigationDrawer.vue
@@ -11,19 +11,25 @@
       v-model:asset-id-value="assetIdValueModel"
       :asset-id-name-suggestions="assetIdNameSuggestions"
       :copy-json-icon="copyJsonIcon"
+      :curl-command="curlCommand"
+      :curl-note="curlNote"
       :descriptors="descriptors"
       :dtr-url="dtrUrl"
       :edc-access-enabled="edcAccessEnabled"
+      :edc-configured-partners="edcConfiguredPartners"
       :edc-counter-party-address="edcCounterPartyAddress"
       :edc-counter-party-id="edcCounterPartyId"
       :edc-partner-id="edcPartnerId"
-      :edc-partners="edcPartners"
+      :edc-partner-ready="edcPartnerReady"
+      :edc-recent-partners="edcRecentPartners"
       embedded
       :has-more-descriptors="hasMoreDescriptors"
+      :infrastructure-editable="infrastructureEditable"
       :inline-error="inlineError"
       :is-loading="isLoading"
       :is-loading-more="isLoadingMore"
       :read-only="readOnly"
+      :runtime-partner-loaded="runtimePartnerLoaded"
       :selected-descriptor-id="selectedDescriptorId"
       @clear="emit('clear')"
       @copy-json="emit('copy-json', $event)"
@@ -32,6 +38,8 @@
       @duplicate="emit('duplicate', $event)"
       @edit="emit('edit', $event)"
       @load-more="emit('load-more')"
+      @load-partner="emit('load-partner')"
+      @save-partner="emit('save-partner')"
       @search="emit('search')"
       @select="emit('select', $event)"
       @update:edc-counter-party-address="emit('update:edc-counter-party-address', $event)"
@@ -53,18 +61,24 @@
     assetIdNameSuggestions: string[]
     assetIdValue: string
     copyJsonIcon: string
+    curlCommand?: string
+    curlNote?: string
     descriptors: any[]
     dtrUrl: string
     edcAccessEnabled?: boolean
+    edcConfiguredPartners?: CatenaXPartner[]
     edcCounterPartyAddress?: string
     edcCounterPartyId?: string
     edcPartnerId?: string
-    edcPartners?: CatenaXPartner[]
+    edcPartnerReady?: boolean
+    edcRecentPartners?: CatenaXPartner[]
     hasMoreDescriptors?: boolean
     inlineError: string
     isLoading: boolean
     isLoadingMore?: boolean
+    infrastructureEditable?: boolean
     readOnly?: boolean
+    runtimePartnerLoaded?: boolean
     selectedDescriptorId: string
   }>()
 
@@ -76,8 +90,10 @@
     'duplicate': [descriptor: any]
     'edit': [descriptor: any]
     'load-more': []
+    'load-partner': []
     'search': []
     'select': [descriptor: any]
+    'save-partner': []
     'update:asset-id-name': [value: string]
     'update:asset-id-value': [value: string]
     'update:edc-counter-party-address': [value: string]

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/components/DescriptorBrowser.vue
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/components/DescriptorBrowser.vue
@@ -8,56 +8,32 @@
     }"
     :rounded="embedded ? false : 'lg'"
   >
-    <div v-if="edcAccessEnabled" class="pa-3 pb-0">
-      <v-row density="compact">
-        <v-col cols="12" md="4">
-          <v-select
-            v-model="edcPartnerIdModel"
-            bg-color="surface-light"
-            density="compact"
-            flat
-            hide-details
-            :items="edcPartnerItems"
-            label="EDC Partner"
-            variant="outlined"
-          />
-        </v-col>
-
-        <v-col cols="12" md="4">
-          <v-text-field
-            v-model="edcCounterPartyIdModel"
-            bg-color="surface-light"
-            density="compact"
-            flat
-            hide-details
-            label="Counterparty ID"
-            placeholder="Counterparty ID"
-            variant="outlined"
-          />
-        </v-col>
-
-        <v-col cols="12" md="4">
-          <v-text-field
-            v-model="edcCounterPartyAddressModel"
-            bg-color="surface-light"
-            density="compact"
-            flat
-            hide-details
-            label="Counterparty DSP Address"
-            placeholder="https://<counterparty-dsp-endpoint>"
-            variant="outlined"
-          />
-        </v-col>
-      </v-row>
-    </div>
+    <EdcPartnerSelector
+      v-if="edcAccessEnabled"
+      v-model:counter-party-address="edcCounterPartyAddressModel"
+      v-model:counter-party-id="edcCounterPartyIdModel"
+      v-model:partner-id="edcPartnerIdModel"
+      :configured-partners="edcConfiguredPartners"
+      :has-load-error="Boolean(inlineError)"
+      :infrastructure-editable="infrastructureEditable"
+      :is-loading="isBusy"
+      :partner-ready="edcPartnerReady"
+      :recent-partners="edcRecentPartners"
+      :runtime-partner-loaded="runtimePartnerLoaded"
+      @load="emit('load-partner')"
+      @save="emit('save-partner')"
+    />
 
     <DescriptorSearchForm
       v-model:asset-id-name="assetIdNameModel"
       v-model:asset-id-value="assetIdValueModel"
       :asset-id-name-suggestions="assetIdNameSuggestions"
+      :curl-command="curlCommand"
+      :curl-note="curlNote"
+      :disabled="isBusy || (edcAccessEnabled && !edcPartnerReady)"
       :dtr-url="dtrUrl"
-      :is-loading="isLoading"
-      :show-curl="!edcAccessEnabled"
+      :is-loading="isBusy"
+      show-curl
       @clear="emit('clear')"
       @search="emit('search')"
     />
@@ -117,6 +93,7 @@
   import DescriptorCreateAction from '@/pages/modules/CatenaXplorer/components/DescriptorCreateAction.vue'
   import DescriptorList from '@/pages/modules/CatenaXplorer/components/DescriptorList.vue'
   import DescriptorSearchForm from '@/pages/modules/CatenaXplorer/components/DescriptorSearchForm.vue'
+  import EdcPartnerSelector from '@/pages/modules/CatenaXplorer/components/EdcPartnerSelector.vue'
 
   const props = defineProps<{
     assetIdName: string
@@ -124,19 +101,25 @@
     assetIdValue: string
     copyJsonIcon: string
     createActionPlacement?: 'fixed' | 'footer'
+    curlCommand?: string
+    curlNote?: string
     descriptors: any[]
     dtrUrl: string
     edcAccessEnabled?: boolean
+    edcConfiguredPartners?: CatenaXPartner[]
     edcCounterPartyAddress?: string
     edcCounterPartyId?: string
     edcPartnerId?: string
-    edcPartners?: CatenaXPartner[]
+    edcPartnerReady?: boolean
+    edcRecentPartners?: CatenaXPartner[]
     embedded?: boolean
     hasMoreDescriptors?: boolean
     inlineError: string
     isLoading: boolean
     isLoadingMore?: boolean
+    infrastructureEditable?: boolean
     readOnly?: boolean
+    runtimePartnerLoaded?: boolean
     selectedDescriptorId: string
   }>()
 
@@ -148,6 +131,8 @@
     'duplicate': [descriptor: any]
     'edit': [descriptor: any]
     'load-more': []
+    'load-partner': []
+    'save-partner': []
     'search': []
     'select': [descriptor: any]
     'update:asset-id-name': [value: string]
@@ -182,15 +167,8 @@
     set: value => emit('update:edc-counter-party-address', value),
   })
 
-  const edcPartnerItems = computed(() => [
-    ...(props.edcPartners ?? []).map(partner => ({
-      title: partner.name || partner.counterPartyId,
-      value: partner.id,
-    })),
-    { title: 'Runtime Partner', value: '' },
-  ])
-
   const isFixedCreateAction = computed(() => props.createActionPlacement === 'fixed')
+  const isBusy = computed(() => props.isLoading || Boolean(props.isLoadingMore))
 </script>
 
 <style scoped>

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/components/DescriptorSearchForm.vue
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/components/DescriptorSearchForm.vue
@@ -6,6 +6,7 @@
       class="asset-id-search-field"
       clearable
       density="compact"
+      :disabled="disabled"
       flat
       hide-details
       label="Search asset ID"
@@ -24,6 +25,7 @@
           bg-color="surface-light"
           class="asset-id-key-select ms-n3"
           density="compact"
+          :disabled="disabled"
           flat
           hide-details
           :items="assetIdNameSuggestions"
@@ -38,8 +40,9 @@
         <v-divider class="asset-id-key-divider mx-1" vertical />
       </template>
 
-      <template v-if="showCurl" #append-inner>
+      <template #append-inner>
         <v-menu
+          v-if="showCurl"
           v-model="curlMenu"
           :close-on-content-click="false"
           location="bottom"
@@ -47,18 +50,7 @@
           open-on-hover
         >
           <template #activator="{ props: menuProps }">
-            <v-btn
-              v-bind="menuProps"
-              aria-label="Search descriptors"
-              class="search-action-button text-buttonText"
-              color="primary"
-              icon="mdi-magnify"
-              :loading="isLoading"
-              rounded="lg"
-              size="x-small"
-              variant="flat"
-              @click.stop="search"
-            />
+            <SearchButton v-bind="menuProps" :disabled="disabled" :is-loading="isLoading" @search="search" />
           </template>
 
           <v-sheet
@@ -88,8 +80,14 @@
             <v-sheet class="pa-2 mt-2" color="surface-light" rounded="lg">
               <code class="curl-preview__code text-label-small text-break">{{ curlCommand }}</code>
             </v-sheet>
+
+            <div v-if="curlNote" class="mt-2 text-caption text-medium-emphasis">
+              {{ curlNote }}
+            </div>
           </v-sheet>
         </v-menu>
+
+        <SearchButton v-else :disabled="disabled" :is-loading="isLoading" @search="search" />
       </template>
 
       <template #clear="{ props: clearProps }">
@@ -103,11 +101,15 @@
   import { computed, ref } from 'vue'
   import { useClipboardUtil } from '@/composables/ClipboardUtil'
   import { buildShellDescriptorsCurlCommand } from '@/pages/modules/CatenaXplorer/catenaXplorerUtils'
+  import SearchButton from '@/pages/modules/CatenaXplorer/components/SearchButton.vue'
 
   const props = defineProps<{
     assetIdName: string
     assetIdNameSuggestions: string[]
     assetIdValue: string
+    curlCommand?: string
+    curlNote?: string
+    disabled?: boolean
     dtrUrl: string
     isLoading: boolean
     showCurl?: boolean
@@ -125,16 +127,25 @@
 
   const assetIdNameModel = computed({
     get: () => props.assetIdName,
-    set: value => emit('update:asset-id-name', value),
+    set: value => {
+      if (!props.disabled) {
+        emit('update:asset-id-name', value)
+      }
+    },
   })
 
   const assetIdValueModel = computed({
     get: () => props.assetIdValue,
-    set: value => emit('update:asset-id-value', value ?? ''),
+    set: value => {
+      if (!props.disabled) {
+        emit('update:asset-id-value', value ?? '')
+      }
+    },
   })
 
   const curlCommand = computed(() => {
-    return buildShellDescriptorsCurlCommand(props.dtrUrl, props.assetIdName, props.assetIdValue)
+    return props.curlCommand
+      || buildShellDescriptorsCurlCommand(props.dtrUrl, props.assetIdName, props.assetIdValue)
   })
 
   const assetIdSelectMenuProps = {
@@ -143,11 +154,16 @@
   } as const
 
   function search (): void {
+    if (props.disabled) {
+      return
+    }
     emit('search')
   }
 
   function clear (): void {
-    emit('clear')
+    if (!props.disabled) {
+      emit('clear')
+    }
   }
 
   function copyCurlCommand (): void {

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/components/EdcPartnerSelector.vue
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/components/EdcPartnerSelector.vue
@@ -1,0 +1,210 @@
+<template>
+  <v-sheet class="pa-3" color="transparent">
+    <v-select
+      v-model="partnerSelection"
+      aria-label="Business partner"
+      bg-color="surface-light"
+      density="compact"
+      :disabled="isLoading"
+      hide-details
+      :items="partnerItems"
+      label="Business partner"
+      variant="outlined"
+    />
+
+    <div v-if="selectedPartner" class="mt-3 pa-3 bg-surface-light rounded-lg">
+      <div class="d-flex align-center ga-2 mb-1">
+        <v-icon icon="mdi-domain" size="small" />
+
+        <span class="text-body-medium font-weight-medium flex-grow-1">
+          {{ selectedPartner.name || selectedPartner.counterPartyId }}
+        </span>
+
+        <v-chip
+          :color="partnerStatus.color"
+          :prepend-icon="partnerStatus.icon"
+          size="x-small"
+          :text="partnerStatus.text"
+          variant="tonal"
+        />
+      </div>
+
+      <div class="text-body-small text-medium-emphasis text-break">
+        {{ selectedPartner.counterPartyId }}
+      </div>
+
+      <div class="text-body-small text-medium-emphasis text-break">
+        {{ selectedPartner.counterPartyAddress }}
+      </div>
+    </div>
+
+    <div v-else class="mt-3">
+      <div class="d-flex justify-end mb-2">
+        <v-chip
+          :color="partnerStatus.color"
+          :prepend-icon="partnerStatus.icon"
+          size="x-small"
+          :text="partnerStatus.text"
+          variant="tonal"
+        />
+      </div>
+
+      <v-text-field
+        v-model="counterPartyIdModel"
+        autocomplete="off"
+        bg-color="surface-light"
+        density="compact"
+        :disabled="isLoading"
+        hide-details="auto"
+        label="Counterparty ID"
+        :rules="[requiredRule]"
+        variant="outlined"
+      />
+
+      <v-text-field
+        v-model="counterPartyAddressModel"
+        autocomplete="url"
+        bg-color="surface-light"
+        class="mt-2"
+        density="compact"
+        :disabled="isLoading"
+        hide-details="auto"
+        label="Counterparty DSP Address"
+        placeholder="https://partner.example/api/v1/dsp"
+        :rules="[requiredRule, addressRule]"
+        variant="outlined"
+      />
+    </div>
+
+    <v-btn
+      block
+      class="mt-3 text-buttonText"
+      color="primary"
+      :disabled="!canLoad"
+      :loading="isLoading"
+      prepend-icon="mdi-cloud-download-outline"
+      :text="partnerReady ? 'Reload all descriptors' : 'Load all descriptors'"
+      variant="flat"
+      @click="emit('load')"
+    />
+
+    <v-btn
+      v-if="runtimePartnerLoaded && infrastructureEditable"
+      block
+      class="mt-2"
+      prepend-icon="mdi-content-save-outline"
+      text="Save partner"
+      variant="outlined"
+      @click="emit('save')"
+    />
+
+    <div
+      v-else-if="runtimePartnerLoaded"
+      class="mt-2 text-caption text-medium-emphasis"
+    >
+      Remembered in this browser. Permanent partners are managed by the deployment configuration.
+    </div>
+  </v-sheet>
+</template>
+
+<script lang="ts" setup>
+  import type { CatenaXPartner } from '@/types/Infrastructure'
+  import { computed } from 'vue'
+  import { isValidCatenaXPartnerAddress } from '@/utils/CatenaXPartnerUtils'
+
+  const runtimePartnerValue = '__runtime_partner__'
+
+  const props = withDefaults(defineProps<{
+    configuredPartners?: CatenaXPartner[]
+    counterPartyAddress?: string
+    counterPartyId?: string
+    infrastructureEditable?: boolean
+    hasLoadError?: boolean
+    isLoading: boolean
+    partnerReady?: boolean
+    partnerId?: string
+    recentPartners?: CatenaXPartner[]
+    runtimePartnerLoaded?: boolean
+  }>(), {
+    configuredPartners: () => [],
+    counterPartyAddress: '',
+    counterPartyId: '',
+    infrastructureEditable: false,
+    hasLoadError: false,
+    partnerId: '',
+    partnerReady: false,
+    recentPartners: () => [],
+    runtimePartnerLoaded: false,
+  })
+
+  const emit = defineEmits<{
+    'load': []
+    'save': []
+    'update:counter-party-address': [value: string]
+    'update:counter-party-id': [value: string]
+    'update:partner-id': [value: string]
+  }>()
+
+  const allPartners = computed(() => [...props.configuredPartners, ...props.recentPartners])
+  const selectedPartner = computed(() =>
+    allPartners.value.find(partner => partner.id === props.partnerId) ?? null,
+  )
+  const canLoad = computed(() =>
+    !props.isLoading
+    && props.counterPartyId.trim() !== ''
+    && isValidCatenaXPartnerAddress(props.counterPartyAddress),
+  )
+  const partnerStatus = computed(() => {
+    if (props.isLoading) {
+      return { color: 'primary', icon: 'mdi-loading', text: 'Loading' }
+    }
+    if (props.partnerReady) {
+      return { color: 'success', icon: 'mdi-check-circle-outline', text: 'Ready' }
+    }
+    if (props.hasLoadError) {
+      return { color: 'error', icon: 'mdi-alert-circle-outline', text: 'Load failed' }
+    }
+    return { color: 'default', icon: 'mdi-clock-outline', text: 'Not loaded' }
+  })
+  const partnerItems = computed(() => {
+    const items: Array<Record<string, unknown>> = []
+    if (props.configuredPartners.length > 0) {
+      items.push(
+        { type: 'subheader', title: 'Configured partners' },
+        ...props.configuredPartners.map(partner => ({
+          title: partner.name || partner.counterPartyId,
+          value: partner.id,
+        })),
+      )
+    }
+    if (props.recentPartners.length > 0) {
+      items.push(
+        { type: 'subheader', title: 'Recently used' },
+        ...props.recentPartners.map(partner => ({
+          title: partner.name || partner.counterPartyId,
+          value: partner.id,
+        })),
+      )
+    }
+    items.push({ type: 'subheader', title: 'Other' }, { title: 'Use another partner…', value: runtimePartnerValue })
+    return items
+  })
+
+  const partnerSelection = computed({
+    get: () => props.partnerId || runtimePartnerValue,
+    set: value => emit('update:partner-id', value === runtimePartnerValue ? '' : value),
+  })
+  const counterPartyIdModel = computed({
+    get: () => props.counterPartyId,
+    set: value => emit('update:counter-party-id', value),
+  })
+  const counterPartyAddressModel = computed({
+    get: () => props.counterPartyAddress,
+    set: value => emit('update:counter-party-address', value),
+  })
+
+  const requiredRule = (value: string): boolean | string => value.trim() !== '' || 'This field is required.'
+  function addressRule (value: string): boolean | string {
+    return isValidCatenaXPartnerAddress(value) || 'Enter an absolute HTTP or HTTPS URL.'
+  }
+</script>

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/components/SearchButton.vue
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/components/SearchButton.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-btn
+    aria-label="Search descriptors"
+    class="search-action-button text-buttonText"
+    color="primary"
+    :disabled="disabled"
+    icon="mdi-magnify"
+    :loading="isLoading"
+    rounded="lg"
+    size="x-small"
+    variant="flat"
+    @click.stop="emit('search')"
+  />
+</template>
+
+<script lang="ts" setup>
+  defineProps<{
+    disabled?: boolean
+    isLoading: boolean
+  }>()
+
+  const emit = defineEmits<{
+    search: []
+  }>()
+</script>

--- a/aas-web-ui/src/pages/modules/CatenaXplorer/index.vue
+++ b/aas-web-ui/src/pages/modules/CatenaXplorer/index.vue
@@ -5,18 +5,24 @@
     v-model:asset-id-value="assetIdValue"
     :asset-id-name-suggestions="assetIdNameSuggestions"
     :copy-json-icon="copyJsonIcon"
+    :curl-command="descriptorCurlCommand"
+    :curl-note="descriptorCurlNote"
     :descriptors="descriptors"
     :dtr-url="dtrUrl"
     :edc-access-enabled="isEdcAccessMode"
+    :edc-configured-partners="configuredEdcPartners"
     :edc-counter-party-address="edcCounterPartyAddress"
     :edc-counter-party-id="edcCounterPartyId"
     :edc-partner-id="selectedEdcPartnerId"
-    :edc-partners="edcPartnerOptions"
+    :edc-partner-ready="edcPartnerReady"
+    :edc-recent-partners="recentEdcPartnerOptions"
     :has-more-descriptors="hasMoreDescriptors"
+    :infrastructure-editable="infrastructureEditable"
     :inline-error="inlineError"
     :is-loading="isLoading"
     :is-loading-more="isLoadingMoreDescriptors"
     :read-only="isEdcAccessMode"
+    :runtime-partner-loaded="runtimePartnerLoaded"
     :selected-descriptor-id="selectedDescriptorId"
     @clear="clearSearch"
     @copy-json="copyDescriptorAsJson"
@@ -25,6 +31,8 @@
     @duplicate="duplicateDescriptor"
     @edit="openEditDescriptorDialog"
     @load-more="loadMoreDescriptors"
+    @load-partner="loadCurrentEdcPartner"
+    @save-partner="savePartnerDialog = true"
     @search="searchDescriptors"
     @select="handleDescriptorSelect"
     @update:edc-counter-party-address="handleEdcCounterPartyAddressUpdate"
@@ -76,18 +84,24 @@
               :asset-id-name-suggestions="assetIdNameSuggestions"
               :copy-json-icon="copyJsonIcon"
               create-action-placement="fixed"
+              :curl-command="descriptorCurlCommand"
+              :curl-note="descriptorCurlNote"
               :descriptors="descriptors"
               :dtr-url="dtrUrl"
               :edc-access-enabled="isEdcAccessMode"
+              :edc-configured-partners="configuredEdcPartners"
               :edc-counter-party-address="edcCounterPartyAddress"
               :edc-counter-party-id="edcCounterPartyId"
               :edc-partner-id="selectedEdcPartnerId"
-              :edc-partners="edcPartnerOptions"
+              :edc-partner-ready="edcPartnerReady"
+              :edc-recent-partners="recentEdcPartnerOptions"
               :has-more-descriptors="hasMoreDescriptors"
+              :infrastructure-editable="infrastructureEditable"
               :inline-error="inlineError"
               :is-loading="isLoading"
               :is-loading-more="isLoadingMoreDescriptors"
               :read-only="isEdcAccessMode"
+              :runtime-partner-loaded="runtimePartnerLoaded"
               :selected-descriptor-id="selectedDescriptorId"
               @clear="clearSearch"
               @copy-json="copyDescriptorAsJson"
@@ -96,6 +110,8 @@
               @duplicate="duplicateDescriptor"
               @edit="openEditDescriptorDialog"
               @load-more="loadMoreDescriptors"
+              @load-partner="loadCurrentEdcPartner"
+              @save-partner="savePartnerDialog = true"
               @search="searchDescriptors"
               @select="handleDescriptorSelect"
               @update:edc-counter-party-address="handleEdcCounterPartyAddressUpdate"
@@ -139,6 +155,15 @@
         :loading="isDeletingDescriptor"
         @delete="deleteDescriptor"
       />
+
+      <CatenaXPartnerDialog
+        v-model="savePartnerDialog"
+        :default-partner-id="selectedEdcConfig?.defaultPartnerId"
+        :existing-partners="configuredEdcPartners"
+        :partner="currentEdcPartner"
+        title="Save business partner"
+        @save="saveRuntimePartner"
+      />
     </div>
   </v-container>
 </template>
@@ -147,22 +172,26 @@
   import type { AasListPageResult, AssetIdFilter } from '@/composables/Client/AASRegistryClient'
   import type { CatenaXEdcDtrMetadata } from '@/composables/Client/CatenaXEdcClient'
   import type { EdcSubmodelViewState } from '@/pages/modules/CatenaXplorer/catenaXplorerUtils'
-  import type { CatenaXPartner } from '@/types/Infrastructure'
+  import type { CatenaXPartner, InfrastructureConfig } from '@/types/Infrastructure'
   import { computed, onMounted, ref, toRaw, watch } from 'vue'
   import { useRoute, useRouter } from 'vue-router'
   import { useDisplay } from 'vuetify'
+  import CatenaXPartnerDialog from '@/components/AppNavigation/Settings/CatenaXPartnerDialog.vue'
   import { useAASRegistryClient } from '@/composables/Client/AASRegistryClient'
   import { useCatenaXEdcClient } from '@/composables/Client/CatenaXEdcClient'
   import { parseNextCursor } from '@/composables/Client/PaginationUtils'
   import { useClipboardUtil } from '@/composables/ClipboardUtil'
   import { useIDUtils } from '@/composables/IDUtils'
   import {
+    forgetRecentCatenaXPartner,
     getRecentCatenaXPartners,
     rememberRecentCatenaXPartner,
   } from '@/pages/modules/CatenaXplorer/catenaXplorerPartners'
   import {
     buildAssetIdNameSuggestions,
+    buildEdcShellDescriptorsCurlCommand,
     buildShellDescriptorEndpointUrl,
+    buildShellDescriptorsCurlCommand,
     getAssetIdNameSuggestions,
     getDescriptorKey,
     getSubmodelEdcEndpointInfo,
@@ -172,7 +201,14 @@
   import DescriptorBrowser from '@/pages/modules/CatenaXplorer/components/DescriptorBrowser.vue'
   import DescriptorDetails from '@/pages/modules/CatenaXplorer/components/DescriptorDetails.vue'
   import DescriptorEditDialog from '@/pages/modules/CatenaXplorer/components/DescriptorEditDialog.vue'
+  import { useEnvStore } from '@/store/EnvironmentStore'
   import { useInfrastructureStore } from '@/store/InfrastructureStore'
+  import { useNavigationStore } from '@/store/NavigationStore'
+  import {
+    getCatenaXPartnerKey,
+    mergeCatenaXPartners,
+    normalizeCatenaXPartners,
+  } from '@/utils/CatenaXPartnerUtils'
   import { base64Decode } from '@/utils/EncodeDecodeUtils'
   import { getCatenaXAccessMode } from '@/utils/InfrastructureUtils'
 
@@ -193,7 +229,9 @@
   const route = useRoute()
   const router = useRouter()
   const display = useDisplay()
+  const envStore = useEnvStore()
   const infrastructureStore = useInfrastructureStore()
+  const navigationStore = useNavigationStore()
   const {
     deleteAasDescriptor,
     fetchAasDescriptorById,
@@ -241,6 +279,9 @@
   const edcCounterPartyId = ref('')
   const edcCounterPartyAddress = ref('')
   const edcProtocol = ref('dataspace-protocol-http')
+  const runtimePartnerLoaded = ref(false)
+  const edcPartnerReady = ref(false)
+  const savePartnerDialog = ref(false)
 
   const selectedInfrastructure = computed(() => infrastructureStore.getSelectedInfrastructure)
   const isEdcAccessMode = computed(() =>
@@ -264,8 +305,64 @@
     return infrastructureStore.getSelectedInfrastructure?.catenaX?.edc ?? null
   })
   const edcProxyId = computed(() => selectedEdcConfig.value?.proxyId?.trim() ?? '')
-  const configuredEdcPartners = computed(() => selectedEdcConfig.value?.partners ?? [])
-  const edcPartnerOptions = computed(() => mergePartners(configuredEdcPartners.value, edcRecentPartners.value))
+  const configuredEdcPartners = computed(() => normalizeCatenaXPartners(selectedEdcConfig.value?.partners ?? []))
+  const recentEdcPartnerOptions = computed(() => {
+    const mergedPartners = mergeCatenaXPartners(configuredEdcPartners.value, edcRecentPartners.value)
+    return mergedPartners.slice(configuredEdcPartners.value.length)
+  })
+  const edcPartnerOptions = computed(() => [
+    ...configuredEdcPartners.value,
+    ...recentEdcPartnerOptions.value,
+  ])
+  const infrastructureEditable = computed(() => envStore.getEndpointConfigAvailable)
+  const currentEdcPartner = computed<Partial<CatenaXPartner>>(() => ({
+    id: selectedEdcPartnerId.value,
+    counterPartyId: edcCounterPartyId.value,
+    counterPartyAddress: edcCounterPartyAddress.value,
+  }))
+  const curlAuthorizationHeader = computed(() => {
+    const securityType = selectedInfrastructure.value?.auth?.securityType
+    if (securityType === 'Basic Authentication') {
+      return 'Basic <BASE64_USERNAME_PASSWORD>'
+    }
+    if (securityType === 'Bearer Token' || securityType === 'OAuth2') {
+      const configuredPrefix = envStore.getAuthorizationPrefix.trim()
+      const prefix = configuredPrefix === '' || configuredPrefix.includes('PLACEHOLDER')
+        ? 'Bearer'
+        : configuredPrefix
+      return `${prefix} <ACCESS_TOKEN>`
+    }
+    return undefined
+  })
+  const descriptorCurlCommand = computed(() => {
+    if (!isEdcAccessMode.value) {
+      return buildShellDescriptorsCurlCommand(
+        dtrUrl.value,
+        assetIdName.value,
+        assetIdValue.value,
+        curlAuthorizationHeader.value,
+      )
+    }
+
+    return buildEdcShellDescriptorsCurlCommand(
+      getEdcDtrDescriptorsEndpointUrl(),
+      edcCounterPartyId.value,
+      edcCounterPartyAddress.value,
+      edcProtocol.value,
+      assetIdName.value,
+      assetIdValue.value,
+      getEdcTransferProcessId(edcDtrAssetKey, edcCounterPartyAddress.value),
+      curlAuthorizationHeader.value,
+    )
+  })
+  const descriptorCurlNote = computed(() => {
+    if (curlAuthorizationHeader.value) {
+      return 'Replace the authorization placeholder before running this command. Stored credentials are never shown in the preview.'
+    }
+    return isEdcAccessMode.value
+      ? 'This command calls the CatenaXplorer BFF, which applies its server-side EDC credentials.'
+      : undefined
+  })
 
   onMounted(() => {
     selectedDescriptorId.value = getRouteDescriptorId()
@@ -296,13 +393,13 @@
   watch(
     () => [
       edcProxyId.value,
-      selectedEdcConfig.value?.defaultPartnerId,
-      configuredEdcPartners.value.length,
       edcProtocol.value,
       isEdcAccessMode.value,
     ],
     () => {
       resetEdcSessionState()
+      edcPartnerReady.value = false
+      runtimePartnerLoaded.value = false
       loadRecentEdcPartners()
       selectDefaultEdcPartner()
       selectedDescriptorId.value = getRouteDescriptorId()
@@ -310,11 +407,27 @@
     },
   )
 
+  watch(
+    () => configuredEdcPartners.value.map(partner => [
+      partner.id,
+      partner.name,
+      partner.counterPartyId,
+      partner.counterPartyAddress,
+    ]),
+    () => syncSelectedEdcPartnerAfterConfigChange(),
+    { deep: true },
+  )
+
   async function reloadDescriptors (): Promise<void> {
     await loadDescriptors()
   }
 
   async function searchDescriptors (): Promise<void> {
+    if (isEdcAccessMode.value && !edcPartnerReady.value) {
+      inlineError.value = 'Load descriptors for the selected business partner before searching.'
+      return
+    }
+
     const name = assetIdName.value.trim()
     const value = assetIdValue.value.trim()
 
@@ -329,6 +442,13 @@
   async function clearSearch (): Promise<void> {
     assetIdName.value = defaultAssetIdName
     assetIdValue.value = ''
+    if (isEdcAccessMode.value && !edcPartnerReady.value) {
+      return
+    }
+    await loadDescriptors()
+  }
+
+  async function loadCurrentEdcPartner (): Promise<void> {
     await loadDescriptors()
   }
 
@@ -349,6 +469,7 @@
     try {
       const page = await fetchDescriptorListPage({
         assetIds: activeAssetIds.value,
+        generation,
         limit: descriptorPageLimit,
       })
 
@@ -363,8 +484,11 @@
       if (selectedDescriptorId.value !== '' && getRouteQueryString(legacyDescriptorIdQueryParam) !== '') {
         updateSelectedDescriptorRoute(selectedDescriptorId.value)
       }
-      await ensureSelectedDescriptorLoaded()
+      await ensureSelectedDescriptorLoaded(generation)
     } catch (error) {
+      if (generation !== descriptorPaginationGeneration.value) {
+        return
+      }
       console.warn(error)
       descriptors.value = []
       selectedDescriptorId.value = getRouteDescriptorId()
@@ -390,6 +514,7 @@
       const page = await fetchDescriptorListPage({
         assetIds: activeAssetIds.value,
         cursor: nextDescriptorCursor.value,
+        generation,
         limit: descriptorPageLimit,
       })
 
@@ -400,8 +525,11 @@
       appendDescriptorPageItems(page.items)
       rememberAssetIdNames(page.items)
       updateDescriptorPaginationState(page)
-      await ensureSelectedDescriptorLoaded()
+      await ensureSelectedDescriptorLoaded(generation)
     } catch (error) {
+      if (generation !== descriptorPaginationGeneration.value) {
+        return
+      }
       console.warn(error)
       inlineError.value = getErrorMessage(error, 'Could not load more AAS descriptors from the Digital Twin Registry.')
     } finally {
@@ -414,6 +542,7 @@
   async function fetchDescriptorListPage (options: {
     assetIds?: AssetIdFilter[]
     cursor?: string
+    generation?: number
     limit?: number
   }): Promise<AasListPageResult<any>> {
     if (!isEdcAccessMode.value) {
@@ -437,7 +566,23 @@
       throw new Error(buildEdcFailureMessage('Could not load AAS descriptors through EDC.'))
     }
 
-    rememberCurrentEdcPartner()
+    if (
+      options.generation !== undefined
+      && options.generation !== descriptorPaginationGeneration.value
+    ) {
+      return {
+        items: [],
+        hasMore: false,
+      }
+    }
+
+    const requestPartnerKey = getCatenaXPartnerKey(edcRequest)
+    const wasRuntimePartner = !configuredEdcPartners.value.some(partner =>
+      getCatenaXPartnerKey(partner) === requestPartnerKey,
+    )
+    rememberCurrentEdcPartner(edcRequest)
+    runtimePartnerLoaded.value = runtimePartnerLoaded.value || wasRuntimePartner
+    edcPartnerReady.value = true
     rememberEdcTransferProcessId(edcDtrAssetKey, response.edc, edcRequest.counterPartyAddress)
     const data = response.data as any
     const nextCursor = parseNextCursor(data)
@@ -450,7 +595,7 @@
     }
   }
 
-  async function fetchDescriptorById (descriptorId: string): Promise<any> {
+  async function fetchDescriptorById (descriptorId: string, generation?: number): Promise<any> {
     if (!isEdcAccessMode.value) {
       return fetchAasDescriptorById(descriptorId)
     }
@@ -470,7 +615,11 @@
       return {}
     }
 
-    rememberCurrentEdcPartner()
+    if (generation !== undefined && generation !== descriptorPaginationGeneration.value) {
+      return {}
+    }
+
+    rememberCurrentEdcPartner(edcRequest)
     rememberEdcTransferProcessId(edcDtrAssetKey, response.edc, edcRequest.counterPartyAddress)
     return response.data
   }
@@ -480,6 +629,7 @@
       return
     }
 
+    const generation = descriptorPaginationGeneration.value
     const stateKey = getDescriptorKey(submodelDescriptor)
     const endpoint = getSubmodelEdcEndpointInfo(submodelDescriptor)
     if (!endpoint) {
@@ -508,6 +658,10 @@
         transferProcessId: getEdcTransferProcessId(endpoint.assetId, endpoint.dspEndpoint),
       })
 
+      if (generation !== descriptorPaginationGeneration.value) {
+        return
+      }
+
       if (!response) {
         updateEdcSubmodelState(stateKey, {
           error: buildEdcFailureMessage('Could not load the Submodel through EDC.'),
@@ -524,6 +678,9 @@
         isLoading: false,
       })
     } catch (error) {
+      if (generation !== descriptorPaginationGeneration.value) {
+        return
+      }
       console.warn(error)
       updateEdcSubmodelState(stateKey, {
         error: buildEdcFailureMessage('Could not load the Submodel through EDC.'),
@@ -534,6 +691,9 @@
 
   function buildEdcFailureMessage (fallback: string): string {
     const details = consumeEdcRequestFailureDetails()?.trim()
+    if (details?.includes('counterPartyAddress is not allowed')) {
+      return `${fallback}\n${details}\nAsk the deployment administrator to add this DSP address to CX_EDC_ALLOWED_COUNTER_PARTY_ADDRESSES.`
+    }
     return details ? `${fallback}\n${details}` : fallback
   }
 
@@ -613,9 +773,39 @@
     ])
   }
 
+  function getEdcDtrDescriptorsEndpointUrl (): string {
+    const configuredBasePath = envStore.getEnvBasePath.trim()
+    let basePath = '/'
+    if (configuredBasePath !== '' && !configuredBasePath.includes('PLACEHOLDER')) {
+      basePath = configuredBasePath.endsWith('/') ? configuredBasePath : `${configuredBasePath}/`
+    }
+    const relativeUrl = `${basePath}api/catena-x/edc/${encodeURIComponent(edcProxyId.value)}/dtr/shell-descriptors`
+    return new URL(relativeUrl, window.location.origin).toString()
+  }
+
   function resetEdcSessionState (): void {
     edcTransferProcessIds.value = {}
     edcSubmodels.value = {}
+  }
+
+  function prepareEdcPartnerChange (): void {
+    const hadSelectedDescriptor = selectedDescriptorId.value !== ''
+      || getRouteQueryString(descriptorEndpointQueryParam) !== ''
+      || getRouteQueryString(legacyDescriptorIdQueryParam) !== ''
+    descriptorPaginationGeneration.value += 1
+    isLoading.value = false
+    isLoadingMoreDescriptors.value = false
+    resetEdcSessionState()
+    runtimePartnerLoaded.value = false
+    edcPartnerReady.value = false
+    descriptors.value = []
+    selectedDescriptorId.value = ''
+    selectedDescriptorFallback.value = null
+    inlineError.value = ''
+    resetDescriptorPaginationState()
+    if (hadSelectedDescriptor) {
+      updateSelectedDescriptorRoute('')
+    }
   }
 
   function updateEdcSubmodelState (key: string, patch: EdcSubmodelViewState): void {
@@ -629,7 +819,16 @@
   }
 
   function loadRecentEdcPartners (): void {
-    edcRecentPartners.value = edcProxyId.value ? getRecentCatenaXPartners(edcProxyId.value) : []
+    const proxyId = edcProxyId.value
+    if (!proxyId) {
+      edcRecentPartners.value = []
+      return
+    }
+
+    for (const partner of configuredEdcPartners.value) {
+      forgetRecentCatenaXPartner(proxyId, partner)
+    }
+    edcRecentPartners.value = getRecentCatenaXPartners(proxyId)
   }
 
   function selectDefaultEdcPartner (): void {
@@ -663,59 +862,113 @@
     selectedEdcPartnerId.value = partnerId
     const partner = edcPartnerOptions.value.find(candidate => candidate.id === partnerId)
     if (!partner) {
-      resetEdcSessionState()
+      edcCounterPartyId.value = ''
+      edcCounterPartyAddress.value = ''
+      prepareEdcPartnerChange()
       return
     }
 
     edcCounterPartyId.value = partner.counterPartyId
     edcCounterPartyAddress.value = partner.counterPartyAddress
-    resetEdcSessionState()
+    prepareEdcPartnerChange()
   }
 
   function handleEdcCounterPartyIdUpdate (value: string): void {
     edcCounterPartyId.value = value
     selectedEdcPartnerId.value = ''
-    resetEdcSessionState()
+    prepareEdcPartnerChange()
   }
 
   function handleEdcCounterPartyAddressUpdate (value: string): void {
     edcCounterPartyAddress.value = value
     selectedEdcPartnerId.value = ''
-    resetEdcSessionState()
+    prepareEdcPartnerChange()
   }
 
-  function rememberCurrentEdcPartner (): void {
+  function rememberCurrentEdcPartner (
+    partner: Pick<CatenaXPartner, 'counterPartyId' | 'counterPartyAddress'> = currentEdcPartner.value as CatenaXPartner,
+  ): void {
+    const partnerKey = getCatenaXPartnerKey(partner)
+    if (configuredEdcPartners.value.some(configuredPartner =>
+      getCatenaXPartnerKey(configuredPartner) === partnerKey,
+    )) {
+      return
+    }
+
     const rememberedPartner = rememberRecentCatenaXPartner(edcProxyId.value, {
-      id: selectedEdcPartnerId.value,
-      counterPartyId: edcCounterPartyId.value,
-      counterPartyAddress: edcCounterPartyAddress.value,
+      id: getCatenaXPartnerKey(currentEdcPartner.value as CatenaXPartner) === partnerKey
+        ? selectedEdcPartnerId.value
+        : '',
+      ...partner,
     })
 
     if (!rememberedPartner) {
       return
     }
 
-    selectedEdcPartnerId.value = rememberedPartner.id
+    if (getCatenaXPartnerKey(currentEdcPartner.value as CatenaXPartner) === partnerKey) {
+      selectedEdcPartnerId.value = rememberedPartner.id
+    }
     loadRecentEdcPartners()
   }
 
-  function mergePartners (...partnerGroups: CatenaXPartner[][]): CatenaXPartner[] {
-    const partnersByKey = new Map<string, CatenaXPartner>()
-    for (const partner of partnerGroups.flat()) {
-      const counterPartyId = partner.counterPartyId.trim()
-      const counterPartyAddress = partner.counterPartyAddress.trim()
-      if (counterPartyId === '' || counterPartyAddress === '') {
-        continue
-      }
-
-      partnersByKey.set(`${counterPartyId}::${counterPartyAddress}`, {
-        ...partner,
-        counterPartyId,
-        counterPartyAddress,
-      })
+  function syncSelectedEdcPartnerAfterConfigChange (): void {
+    const selectedPartner = edcPartnerOptions.value.find(partner => partner.id === selectedEdcPartnerId.value)
+    if (!selectedPartner) {
+      selectDefaultEdcPartner()
+      prepareEdcPartnerChange()
+      return
     }
 
-    return Array.from(partnersByKey.values())
+    const connectionChanged = selectedPartner.counterPartyId !== edcCounterPartyId.value
+      || selectedPartner.counterPartyAddress !== edcCounterPartyAddress.value
+    edcCounterPartyId.value = selectedPartner.counterPartyId
+    edcCounterPartyAddress.value = selectedPartner.counterPartyAddress
+    if (connectionChanged) {
+      prepareEdcPartnerChange()
+    }
+  }
+
+  function saveRuntimePartner (partner: CatenaXPartner, useAsDefault: boolean): void {
+    const infrastructure = selectedInfrastructure.value
+    const edc = infrastructure?.catenaX?.edc
+    if (!infrastructure || !edc || !infrastructureEditable.value) {
+      return
+    }
+
+    const updatedInfrastructure = structuredClone(toRaw(infrastructure))
+    const updatedEdc = updatedInfrastructure.catenaX!.edc!
+    const partnerKey = getCatenaXPartnerKey(partner)
+    const existingPartners = normalizeCatenaXPartners(updatedEdc.partners ?? [])
+    const matchingPartner = existingPartners.find(candidate => getCatenaXPartnerKey(candidate) === partnerKey)
+    const savedPartner = {
+      ...partner,
+      id: matchingPartner?.id ?? partner.id,
+    }
+    updatedEdc.partners = [
+      ...existingPartners.filter(candidate => getCatenaXPartnerKey(candidate) !== partnerKey),
+      savedPartner,
+    ]
+
+    if (useAsDefault || !updatedEdc.defaultPartnerId) {
+      updatedEdc.defaultPartnerId = savedPartner.id
+    }
+    synchronizeLegacyDefaultPartner(updatedEdc)
+    selectedEdcPartnerId.value = savedPartner.id
+    infrastructureStore.dispatchUpdateInfrastructure(updatedInfrastructure)
+    navigationStore.dispatchSnackbar({
+      status: true,
+      timeout: 5000,
+      color: 'success',
+      btnColor: 'buttonText',
+      text: `Saved partner "${savedPartner.name || savedPartner.counterPartyId}".`,
+    })
+  }
+
+  function synchronizeLegacyDefaultPartner (edc: NonNullable<NonNullable<InfrastructureConfig['catenaX']>['edc']>): void {
+    const defaultPartner = edc.partners?.find(partner => partner.id === edc.defaultPartnerId)
+    edc.defaultCounterPartyId = defaultPartner?.counterPartyId
+    edc.defaultCounterPartyAddress = defaultPartner?.counterPartyAddress
   }
 
   function beginDescriptorPagination (assetIds?: AssetIdFilter[]): number {
@@ -784,7 +1037,9 @@
     return normalizedAssetIds && normalizedAssetIds.length > 0 ? normalizedAssetIds : undefined
   }
 
-  async function ensureSelectedDescriptorLoaded (): Promise<void> {
+  async function ensureSelectedDescriptorLoaded (
+    generation = descriptorPaginationGeneration.value,
+  ): Promise<void> {
     const descriptorId = selectedDescriptorId.value.trim()
     if (descriptorId === '') {
       selectedDescriptorFallback.value = null
@@ -805,7 +1060,10 @@
       return
     }
 
-    const descriptor = await fetchDescriptorById(descriptorId)
+    const descriptor = await fetchDescriptorById(descriptorId, generation)
+    if (generation !== descriptorPaginationGeneration.value) {
+      return
+    }
     if (descriptor && Object.keys(descriptor).length > 0) {
       selectedDescriptorFallback.value = descriptor
       rememberAssetIdNames([descriptor])

--- a/aas-web-ui/src/utils/CatenaXPartnerUtils.ts
+++ b/aas-web-ui/src/utils/CatenaXPartnerUtils.ts
@@ -1,0 +1,107 @@
+import type { CatenaXPartner } from '@/types/Infrastructure'
+
+export function normalizeCatenaXPartner (
+  partner: Partial<CatenaXPartner>,
+): CatenaXPartner | null {
+  const counterPartyId = normalizeText(partner.counterPartyId)
+  const counterPartyAddress = normalizeText(partner.counterPartyAddress)
+  if (counterPartyId === '' || counterPartyAddress === '') {
+    return null
+  }
+
+  return {
+    id: normalizeText(partner.id) || createCatenaXPartnerId(counterPartyId, counterPartyAddress),
+    name: normalizeText(partner.name) || undefined,
+    counterPartyId,
+    counterPartyAddress,
+  }
+}
+
+export function normalizeCatenaXPartners (partners: unknown): CatenaXPartner[] {
+  if (!Array.isArray(partners)) {
+    return []
+  }
+
+  const partnersByKey = new Map<string, CatenaXPartner>()
+  for (const partner of partners) {
+    const normalizedPartner = normalizeCatenaXPartner(partner as Partial<CatenaXPartner>)
+    if (!normalizedPartner) {
+      continue
+    }
+
+    partnersByKey.set(getCatenaXPartnerKey(normalizedPartner), normalizedPartner)
+  }
+
+  return Array.from(partnersByKey.values())
+}
+
+export function mergeCatenaXPartners (
+  configuredPartners: CatenaXPartner[],
+  recentPartners: CatenaXPartner[],
+): CatenaXPartner[] {
+  const configured = normalizeCatenaXPartners(configuredPartners)
+  const configuredKeys = new Set(configured.map(partner => getCatenaXPartnerKey(partner)))
+  const recent = normalizeCatenaXPartners(recentPartners)
+    .filter(partner => !configuredKeys.has(getCatenaXPartnerKey(partner)))
+
+  return [...configured, ...recent]
+}
+
+export function createCatenaXPartnerId (
+  counterPartyId: string,
+  counterPartyAddress: string,
+  existingIds: string[] = [],
+): string {
+  const baseId = `${counterPartyId}-${counterPartyAddress}`
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '') || 'partner'
+  const usedIds = new Set(existingIds.map(id => id.trim()).filter(Boolean))
+
+  if (!usedIds.has(baseId)) {
+    return baseId
+  }
+
+  let suffix = 2
+  while (usedIds.has(`${baseId}-${suffix}`)) {
+    suffix += 1
+  }
+
+  return `${baseId}-${suffix}`
+}
+
+export function getCatenaXPartnerKey (
+  partner: Pick<CatenaXPartner, 'counterPartyId' | 'counterPartyAddress'>,
+): string {
+  return `${partner.counterPartyId.trim()}::${canonicalizeCatenaXPartnerAddress(partner.counterPartyAddress)}`
+}
+
+export function canonicalizeCatenaXPartnerAddress (value: string): string {
+  const trimmedValue = value.trim()
+
+  try {
+    const url = new URL(trimmedValue)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return trimmedValue
+    }
+
+    url.hash = ''
+    url.pathname = url.pathname.replace(/\/+$/, '')
+    return url.toString().replace(/\/$/, '')
+  } catch {
+    return trimmedValue
+  }
+}
+
+export function isValidCatenaXPartnerAddress (value: string): boolean {
+  try {
+    const url = new URL(value.trim())
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.host !== ''
+  } catch {
+    return false
+  }
+}
+
+function normalizeText (value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}

--- a/aas-web-ui/tests/components/AppNavigation/Settings/CatenaXEdcConfigPanel.test.ts
+++ b/aas-web-ui/tests/components/AppNavigation/Settings/CatenaXEdcConfigPanel.test.ts
@@ -1,0 +1,181 @@
+import type { CatenaXPartner } from '@/types/Infrastructure'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+import CatenaXEdcConfigPanel from '@/components/AppNavigation/Settings/CatenaXEdcConfigPanel.vue'
+
+const VBtnStub = defineComponent({
+  props: {
+    text: String,
+  },
+  emits: ['click'],
+  template: '<button v-bind="$attrs" type="button" @click="$emit(\'click\', $event)">{{ text }}<slot /></button>',
+})
+
+const VDialogStub = defineComponent({
+  props: {
+    modelValue: Boolean,
+  },
+  template: '<div v-if="modelValue"><slot /></div>',
+})
+
+const PartnerDialogStub = defineComponent({
+  name: 'CatenaXPartnerDialog',
+  props: {
+    allowDefault: Boolean,
+    modelValue: Boolean,
+  },
+  emits: ['save', 'update:modelValue'],
+  setup (_props, { emit }) {
+    const partner: CatenaXPartner = {
+      id: 'partner-b',
+      name: 'Partner B',
+      counterPartyId: 'BPNL0002',
+      counterPartyAddress: 'https://partner-b.example/dsp',
+    }
+    function save (): void {
+      emit('save', partner, true)
+    }
+    return { save }
+  },
+  template: '<button v-if="modelValue" data-testid="save-dialog" :data-allow-default="allowDefault" type="button" @click="save">Save dialog</button>',
+})
+
+const SlotStub = defineComponent({
+  template: '<div><slot name="prepend" /><slot /><slot name="append" /><slot name="activator" :props="{}" /></div>',
+})
+
+const VTextFieldStub = defineComponent({
+  props: {
+    modelValue: String,
+  },
+  template: '<input :value="modelValue">',
+})
+
+const partners: CatenaXPartner[] = [
+  {
+    id: 'partner-a',
+    name: 'Partner A',
+    counterPartyId: 'BPNL0001',
+    counterPartyAddress: 'https://partner-a.example/dsp',
+  },
+]
+
+function createWrapper (configuredPartners = partners) {
+  return mount(CatenaXEdcConfigPanel, {
+    props: {
+      modelValue: {
+        accessMode: 'edc',
+        edc: {
+          proxyId: 'default',
+          defaultPartnerId: configuredPartners[0]?.id,
+          partners: configuredPartners,
+        },
+      },
+    },
+    global: {
+      stubs: {
+        CatenaXPartnerDialog: PartnerDialogStub,
+        VAlert: SlotStub,
+        VBtn: VBtnStub,
+        VCard: SlotStub,
+        VCardActions: SlotStub,
+        VCardText: SlotStub,
+        VCardTitle: SlotStub,
+        VChip: SlotStub,
+        VContainer: SlotStub,
+        VDialog: VDialogStub,
+        VDivider: true,
+        VList: SlotStub,
+        VListItem: SlotStub,
+        VListItemSubtitle: SlotStub,
+        VListItemTitle: SlotStub,
+        VRadio: true,
+        VRadioGroup: SlotStub,
+        VSpacer: true,
+        VTextField: VTextFieldStub,
+        VTooltip: SlotStub,
+      },
+    },
+  })
+}
+
+describe('CatenaXEdcConfigPanel.vue', () => {
+  it('adds a partner, makes it default, and synchronizes legacy defaults', async () => {
+    const wrapper = createWrapper()
+    const addButton = wrapper.findAll('button').find(button => button.text().includes('Add business partner'))!
+
+    await addButton.trigger('click')
+    await wrapper.get('[data-testid="save-dialog"]').trigger('click')
+
+    expect(wrapper.emitted('update:model-value')?.at(-1)?.[0]).toEqual({
+      accessMode: 'edc',
+      edc: {
+        proxyId: 'default',
+        defaultPartnerId: 'partner-b',
+        defaultCounterPartyId: 'BPNL0002',
+        defaultCounterPartyAddress: 'https://partner-b.example/dsp',
+        partners: [...partners, {
+          id: 'partner-b',
+          name: 'Partner B',
+          counterPartyId: 'BPNL0002',
+          counterPartyAddress: 'https://partner-b.example/dsp',
+        }],
+      },
+    })
+  })
+
+  it('promotes the next partner when deleting the default', async () => {
+    const secondPartner: CatenaXPartner = {
+      id: 'partner-b',
+      name: 'Partner B',
+      counterPartyId: 'BPNL0002',
+      counterPartyAddress: 'https://partner-b.example/dsp',
+    }
+    const wrapper = createWrapper([...partners, secondPartner])
+
+    await wrapper.get('[aria-label="Delete Partner A"]').trigger('click')
+    expect(wrapper.text()).toContain('“Partner B” will become the default partner.')
+    const deleteButton = wrapper.findAll('button').find(button => button.text() === 'Delete')!
+    await deleteButton.trigger('click')
+
+    expect(wrapper.emitted('update:model-value')?.at(-1)?.[0]).toEqual({
+      accessMode: 'edc',
+      edc: {
+        proxyId: 'default',
+        defaultPartnerId: 'partner-b',
+        defaultCounterPartyId: 'BPNL0002',
+        defaultCounterPartyAddress: 'https://partner-b.example/dsp',
+        partners: [secondPartner],
+      },
+    })
+  })
+
+  it('selects the default from the full row without opening edit and hides default choice while editing', async () => {
+    const secondPartner: CatenaXPartner = {
+      id: 'partner-b',
+      name: 'Partner B',
+      counterPartyId: 'BPNL0002',
+      counterPartyAddress: 'https://partner-b.example/dsp',
+    }
+    const wrapper = createWrapper([...partners, secondPartner])
+
+    await wrapper.get('[aria-label="Use Partner B as default partner"]').trigger('click')
+    expect(wrapper.emitted('update:model-value')?.at(-1)?.[0]).toMatchObject({
+      edc: {
+        defaultPartnerId: 'partner-b',
+        defaultCounterPartyId: 'BPNL0002',
+      },
+    })
+
+    await wrapper.get('[aria-label="Edit Partner A"]').trigger('click')
+    expect(wrapper.get('[data-testid="save-dialog"]').attributes('data-allow-default')).toBe('false')
+  })
+
+  it('warns when deleting the final default partner', async () => {
+    const wrapper = createWrapper()
+
+    await wrapper.get('[aria-label="Delete Partner A"]').trigger('click')
+    expect(wrapper.text()).toContain('No default partner will remain.')
+  })
+})

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureYamlParser.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureYamlParser.test.ts
@@ -178,8 +178,8 @@ describe('useInfrastructureYamlParser.ts', () => {
 
     expect(parsed.infrastructures[0].catenaX?.edc).toEqual({
       proxyId: 'default',
-      defaultCounterPartyId: undefined,
-      defaultCounterPartyAddress: undefined,
+      defaultCounterPartyId: 'TEST_PARTICIPANT_ID',
+      defaultCounterPartyAddress: 'https://counterparty-dsp.test/api/v1/dsp',
       defaultPartnerId: 'partner-a',
       partners: [
         {

--- a/aas-web-ui/tests/pages/modules/CatenaXplorer/DescriptorSearchForm.test.ts
+++ b/aas-web-ui/tests/pages/modules/CatenaXplorer/DescriptorSearchForm.test.ts
@@ -16,6 +16,7 @@ const VSelectStub = defineComponent({
       type: Array,
       default: () => [],
     },
+    disabled: Boolean,
     modelValue: String,
   },
   emits: ['keydown', 'update:modelValue'],
@@ -27,7 +28,7 @@ const VSelectStub = defineComponent({
     return { onChange }
   },
   template: `
-    <select data-testid="asset-key" :value="modelValue" @change="onChange" @keydown="$emit('keydown', $event)">
+    <select data-testid="asset-key" :disabled="disabled" :value="modelValue" @change="onChange" @keydown="$emit('keydown', $event)">
       <option v-for="item in items" :key="String(item)" :value="item">{{ item }}</option>
     </select>
   `,
@@ -36,6 +37,7 @@ const VSelectStub = defineComponent({
 const VTextFieldStub = defineComponent({
   name: 'VTextField',
   props: {
+    disabled: Boolean,
     label: String,
     modelValue: String,
   },
@@ -51,7 +53,7 @@ const VTextFieldStub = defineComponent({
     <label data-testid="asset-value-field">
       <slot name="prepend-inner" />
       <span>{{ label }}</span>
-      <input data-testid="asset-value" :value="modelValue" @input="onInput" @keydown="$emit('keydown', $event)">
+      <input data-testid="asset-value" :disabled="disabled" :value="modelValue" @input="onInput" @keydown="$emit('keydown', $event)">
       <slot name="append-inner" />
       <button data-testid="clear-field" type="button" @click="$emit('click:clear')">clear</button>
       <slot name="clear" :props="{}" />
@@ -79,7 +81,7 @@ const SlotStub = defineComponent({
   template: '<div><slot name="activator" :props="{}" /><slot /></div>',
 })
 
-function createWrapper () {
+function createWrapper (overrides: Record<string, unknown> = {}) {
   return mount(DescriptorSearchForm, {
     props: {
       assetIdName: 'manufacturerPartId',
@@ -87,6 +89,7 @@ function createWrapper () {
       assetIdValue: '',
       dtrUrl: 'https://registry.example/api/v3',
       isLoading: false,
+      ...overrides,
     },
     global: {
       stubs: {
@@ -130,5 +133,40 @@ describe('DescriptorSearchForm.vue', () => {
     expect(wrapper.emitted('search')).toHaveLength(1)
     expect(wrapper.emitted('clear')).toHaveLength(1)
     expect(wrapper.find('[aria-label="Search options"]').exists()).toBe(false)
+  })
+
+  it('keeps the search action visible when the cURL preview is disabled', async () => {
+    const wrapper = createWrapper()
+    const searchButton = wrapper.find('[aria-label="Search descriptors"]')
+
+    expect(searchButton.exists()).toBe(true)
+    await searchButton.trigger('click')
+
+    expect(wrapper.emitted('search')).toHaveLength(1)
+  })
+
+  it('renders a supplied EDC cURL command and authentication note', () => {
+    const wrapper = createWrapper({
+      curlCommand: 'curl -X POST \'https://ui.example/api/catena-x/edc/default/dtr/shell-descriptors\'',
+      curlNote: 'Browser authentication headers are omitted from this command.',
+      showCurl: true,
+    })
+
+    expect(wrapper.text()).toContain('curl -X POST')
+    expect(wrapper.text()).toContain('Browser authentication headers are omitted')
+    expect(wrapper.find('[aria-label="Copy cURL request"]').exists()).toBe(true)
+  })
+
+  it('locks both search inputs and actions while a request is active', async () => {
+    const wrapper = createWrapper({ disabled: true, isLoading: true })
+
+    expect(wrapper.get('[data-testid="asset-key"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.get('[data-testid="asset-value"]').attributes('disabled')).toBeDefined()
+    expect(wrapper.get('[aria-label="Search descriptors"]').attributes('disabled')).toBeDefined()
+
+    await wrapper.get('[data-testid="asset-value"]').setValue('PART-002')
+    await wrapper.get('[data-testid="clear-field"]').trigger('click')
+    expect(wrapper.emitted('update:asset-id-value')).toBeUndefined()
+    expect(wrapper.emitted('clear')).toBeUndefined()
   })
 })

--- a/aas-web-ui/tests/pages/modules/CatenaXplorer/EdcPartnerSelector.test.ts
+++ b/aas-web-ui/tests/pages/modules/CatenaXplorer/EdcPartnerSelector.test.ts
@@ -1,0 +1,122 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent } from 'vue'
+import EdcPartnerSelector from '@/pages/modules/CatenaXplorer/components/EdcPartnerSelector.vue'
+
+const VSelectStub = defineComponent({
+  props: {
+    items: Array,
+    modelValue: String,
+  },
+  emits: ['update:modelValue'],
+  template: '<select data-testid="partner" :value="modelValue" @change="$emit(\'update:modelValue\', $event.target.value)"><option value="configured">Configured</option><option value="__runtime_partner__">Use another partner</option></select>',
+})
+
+const VTextFieldStub = defineComponent({
+  props: {
+    label: String,
+    modelValue: String,
+  },
+  emits: ['update:modelValue'],
+  template: '<label><span>{{ label }}</span><input :aria-label="label" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)"></label>',
+})
+
+const VBtnStub = defineComponent({
+  props: {
+    disabled: Boolean,
+    text: String,
+  },
+  emits: ['click'],
+  template: '<button :disabled="disabled" type="button" @click="$emit(\'click\')">{{ text }}</button>',
+})
+
+const VChipStub = defineComponent({
+  props: {
+    text: String,
+  },
+  template: '<span>{{ text }}</span>',
+})
+
+function createWrapper (overrides: Record<string, unknown> = {}) {
+  return mount(EdcPartnerSelector, {
+    props: {
+      configuredPartners: [{
+        id: 'configured',
+        name: 'Configured Partner',
+        counterPartyId: 'BPNL0001',
+        counterPartyAddress: 'https://configured.example/dsp',
+      }],
+      counterPartyAddress: 'https://configured.example/dsp',
+      counterPartyId: 'BPNL0001',
+      isLoading: false,
+      partnerId: 'configured',
+      ...overrides,
+    },
+    global: {
+      stubs: {
+        VBtn: VBtnStub,
+        VChip: VChipStub,
+        VIcon: true,
+        VSelect: VSelectStub,
+        VSheet: { template: '<div><slot /></div>' },
+        VTextField: VTextFieldStub,
+      },
+    },
+  })
+}
+
+describe('EdcPartnerSelector.vue', () => {
+  it('shows configured partner details and requests runtime mode explicitly', async () => {
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('Configured Partner')
+    await wrapper.find('[data-testid="partner"]').setValue('__runtime_partner__')
+
+    expect(wrapper.emitted('update:partner-id')?.[0]).toEqual([''])
+  })
+
+  it('distinguishes prepared, ready, loading, and failed partner states', async () => {
+    const wrapper = createWrapper()
+
+    expect(wrapper.text()).toContain('Not loaded')
+    expect(wrapper.text()).toContain('Load all descriptors')
+
+    await wrapper.setProps({ partnerReady: true })
+    expect(wrapper.text()).toContain('Ready')
+    expect(wrapper.text()).toContain('Reload all descriptors')
+
+    await wrapper.setProps({ isLoading: true, partnerReady: false })
+    expect(wrapper.text()).toContain('Loading')
+
+    await wrapper.setProps({ hasLoadError: true, isLoading: false })
+    expect(wrapper.text()).toContain('Load failed')
+  })
+
+  it('requires valid runtime values before loading', async () => {
+    const wrapper = createWrapper({
+      counterPartyAddress: '',
+      counterPartyId: '',
+      partnerId: '',
+    })
+    const loadButton = wrapper.get('button')
+
+    expect(loadButton.attributes('disabled')).toBeDefined()
+    await wrapper.setProps({
+      counterPartyAddress: 'https://runtime.example/dsp',
+      counterPartyId: 'BPNL0002',
+    })
+
+    expect(loadButton.attributes('disabled')).toBeUndefined()
+    await loadButton.trigger('click')
+    expect(wrapper.emitted('load')).toHaveLength(1)
+  })
+
+  it('offers saving only after an unconfigured partner loaded in editable mode', () => {
+    const wrapper = createWrapper({
+      infrastructureEditable: true,
+      runtimePartnerLoaded: true,
+    })
+
+    expect(wrapper.findAll('button').map(button => button.text())).toContain('Save partner')
+  })
+})

--- a/aas-web-ui/tests/pages/modules/CatenaXplorer/catenaXplorerPartners.test.ts
+++ b/aas-web-ui/tests/pages/modules/CatenaXplorer/catenaXplorerPartners.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import {
+  forgetRecentCatenaXPartner,
   getRecentCatenaXPartners,
   rememberRecentCatenaXPartner,
 } from '@/pages/modules/CatenaXplorer/catenaXplorerPartners'
@@ -33,5 +34,19 @@ describe('catenaXplorerPartners.ts', () => {
       },
     ])
     expect(getRecentCatenaXPartners('other')).toHaveLength(1)
+  })
+
+  it('forgets a configured partner using its canonical endpoint identity', () => {
+    rememberRecentCatenaXPartner('default', {
+      counterPartyId: 'TEST_PARTICIPANT_ID',
+      counterPartyAddress: 'https://partner.example:443/dsp/',
+    })
+
+    forgetRecentCatenaXPartner('default', {
+      counterPartyId: 'TEST_PARTICIPANT_ID',
+      counterPartyAddress: 'https://PARTNER.example/dsp',
+    })
+
+    expect(getRecentCatenaXPartners('default')).toEqual([])
   })
 })

--- a/aas-web-ui/tests/pages/modules/CatenaXplorer/catenaXplorerUtils.test.ts
+++ b/aas-web-ui/tests/pages/modules/CatenaXplorer/catenaXplorerUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   buildAssetIdNameSuggestions,
+  buildEdcShellDescriptorsCurlCommand,
   buildShellDescriptorEndpointUrl,
   buildShellDescriptorsCurlCommand,
   buildShellDescriptorsRequestUrl,
@@ -56,6 +57,42 @@ describe('catenaXplorerUtils.ts', () => {
       'manufacturerPartId',
       '',
     )).toBe('curl -X GET \'http://localhost:5004/api/v3/shell-descriptors?limit=100\'')
+  })
+
+  it('builds an effective EDC BFF cURL command with the current asset filter', () => {
+    expect(buildEdcShellDescriptorsCurlCommand(
+      'https://ui.example/api/catena-x/edc/default/dtr/shell-descriptors',
+      'BPNL0001',
+      'https://partner.example/api/v1/dsp',
+      'dataspace-protocol-http',
+      'manufacturerPartId',
+      'PART-001',
+      'transfer-123',
+    )).toBe(
+      'curl -X POST \'https://ui.example/api/catena-x/edc/default/dtr/shell-descriptors\' \\\n'
+      + '  -H \'Content-Type: application/json\' \\\n'
+      + '  --data-raw \'{"counterPartyId":"BPNL0001","counterPartyAddress":"https://partner.example/api/v1/dsp","protocol":"dataspace-protocol-http","limit":100,"assetIds":[{"name":"manufacturerPartId","value":"PART-001"}],"transferProcessId":"transfer-123"}\'',
+    )
+  })
+
+  it('adds safe authorization placeholders to cURL commands', () => {
+    expect(buildShellDescriptorsCurlCommand(
+      'https://registry.example/api/v3',
+      'manufacturerPartId',
+      'PART-001',
+      'Bearer <ACCESS_TOKEN>',
+    )).toContain('-H \'Authorization: Bearer <ACCESS_TOKEN>\'')
+
+    expect(buildEdcShellDescriptorsCurlCommand(
+      'https://ui.example/api/catena-x/edc/default/dtr/shell-descriptors',
+      'BPNL0001',
+      'https://partner.example/dsp',
+      'dataspace-protocol-http',
+      'manufacturerPartId',
+      'PART-001',
+      undefined,
+      'Basic <BASE64_USERNAME_PASSWORD>',
+    )).toContain('-H \'Authorization: Basic <BASE64_USERNAME_PASSWORD>\'')
   })
 
   it('extracts unique asset ID name suggestions from descriptors', () => {

--- a/aas-web-ui/tests/utils/CatenaXPartnerUtils.test.ts
+++ b/aas-web-ui/tests/utils/CatenaXPartnerUtils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canonicalizeCatenaXPartnerAddress,
+  createCatenaXPartnerId,
+  getCatenaXPartnerKey,
+  isValidCatenaXPartnerAddress,
+  mergeCatenaXPartners,
+  normalizeCatenaXPartners,
+} from '@/utils/CatenaXPartnerUtils'
+
+describe('CatenaXPartnerUtils.ts', () => {
+  it('normalizes and de-duplicates partners by counterparty and address', () => {
+    expect(normalizeCatenaXPartners([
+      {
+        id: 'first',
+        counterPartyId: ' BPNL0001 ',
+        counterPartyAddress: ' https://partner.example/dsp ',
+      },
+      {
+        id: 'second',
+        name: 'Partner',
+        counterPartyId: 'BPNL0001',
+        counterPartyAddress: 'https://partner.example/dsp',
+      },
+    ])).toEqual([{
+      id: 'second',
+      name: 'Partner',
+      counterPartyId: 'BPNL0001',
+      counterPartyAddress: 'https://partner.example/dsp',
+    }])
+  })
+
+  it('keeps configured partner metadata ahead of matching recent entries', () => {
+    const configured = [{
+      id: 'configured-id',
+      name: 'Configured Partner',
+      counterPartyId: 'BPNL0001',
+      counterPartyAddress: 'https://partner.example/dsp',
+    }]
+    const recent = [{
+      id: 'recent-id',
+      counterPartyId: 'BPNL0001',
+      counterPartyAddress: 'https://partner.example/dsp',
+    }]
+
+    expect(mergeCatenaXPartners(configured, recent)).toEqual(configured)
+  })
+
+  it('uses a canonical URL for duplicate comparison without changing stored addresses', () => {
+    expect(canonicalizeCatenaXPartnerAddress(' HTTPS://PARTNER.EXAMPLE:443/dsp/ '))
+      .toBe('https://partner.example/dsp')
+    expect(getCatenaXPartnerKey({
+      counterPartyId: 'BPNL0001',
+      counterPartyAddress: 'https://PARTNER.example:443/dsp/',
+    })).toBe('BPNL0001::https://partner.example/dsp')
+    expect(normalizeCatenaXPartners([{
+      id: 'configured',
+      counterPartyId: 'BPNL0001',
+      counterPartyAddress: 'https://PARTNER.example:443/dsp/',
+    }])[0]?.counterPartyAddress).toBe('https://PARTNER.example:443/dsp/')
+  })
+
+  it('creates collision-safe IDs and accepts only absolute HTTP addresses', () => {
+    const baseId = createCatenaXPartnerId('BPNL0001', 'https://partner.example/dsp')
+
+    expect(createCatenaXPartnerId('BPNL0001', 'https://partner.example/dsp', [baseId])).toBe(`${baseId}-2`)
+    expect(isValidCatenaXPartnerAddress('https://partner.example/dsp')).toBe(true)
+    expect(isValidCatenaXPartnerAddress('http://localhost:8185/dsp')).toBe(true)
+    expect(isValidCatenaXPartnerAddress('/relative/dsp')).toBe(false)
+  })
+})

--- a/examples/CatenaXplorerEdcStandalone/README.md
+++ b/examples/CatenaXplorerEdcStandalone/README.md
@@ -138,6 +138,10 @@ partners:
 
 The provider DSP endpoint in `basyx-infra.yml` must match one of the prefixes in `CX_EDC_ALLOWED_COUNTER_PARTY_ADDRESSES`.
 
+When `VITE_ENDPOINT_CONFIG_AVAILABLE=true`, partners can also be managed from **Settings → Manage Infrastructures**. Edit the Catena-X EDC infrastructure, then add, edit, remove, or choose the default business partner. These UI changes are stored in the current browser; server credentials and the DSP address allowlist remain deployment settings.
+
+In CatenaXplorer, selecting a partner prepares the new context and clears results from the previous provider. Select **Load descriptors** to start the EDC request. To use an unconfigured provider, select **Use another partner…**, enter its counterparty ID and DSP address, and load it. After a successful request, the partner is remembered in that browser and can be saved to the editable infrastructure.
+
 ## Optional User Authentication
 
 If your company does have an identity provider and wants the backend to validate browser users before EDC access, switch from `none` to `jwt`.
@@ -200,8 +204,8 @@ In the browser:
 
 1. Open the UI.
 2. The CatenaXplorer page should open by default.
-3. Select the configured partner or enter an allowed runtime partner.
-4. Load descriptors.
+3. Select the configured partner or choose **Use another partner…** and enter an allowed runtime partner.
+4. Select **Load descriptors**.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## What changed

- made partner selection explicit, with a separate action to load descriptors
- added multi-partner management to the Catena-X infrastructure settings
- added clear loading, validation, save, recent-partner, and default-partner states
- restored an effective cURL preview for descriptor searches without exposing credentials
- kept legacy default-partner fields synchronized for backwards compatibility

## Why

Changing the selected partner previously looked like it should start a request, but it only updated local state. Partner configuration was also limited to the YAML defaults. This makes the workflow clearer and allows browser-local partner management without expanding the server-side security boundary.
