### PR TITLE
Fix YAML infrastructure preconfiguration in production

### DIFF
--- a/aas-web-ui/entrypoint.sh
+++ b/aas-web-ui/entrypoint.sh
@@ -201,7 +201,7 @@ find /usr/src/app/dist -type f \( -name '*.js' -o -name '*.html' -o -name '*.css
     -e "s|/__AAS_REPO_PATH_PLACEHOLDER__/|$AAS_REPO_PATH|g" \
     -e "s|/__SUBMODEL_REPO_PATH_PLACEHOLDER__/|$SUBMODEL_REPO_PATH|g" \
     -e "s|/__CD_REPO_PATH_PLACEHOLDER__/|$CD_REPO_PATH|g" \
-    -e "s|/__COMPANY_LOOKUP_PLACEHOLDER__/|$COMPANY_LOOKUP_PATH|g" \
+    -e "s|/__COMPANY_LOOKUP_PATH_PLACEHOLDER__/|$COMPANY_LOOKUP_PATH|g" \
     -e "s|/__PRIMARY_LIGHT_COLOR_PLACEHOLDER__/|$PRIMARY_LIGHT_COLOR|g" \
     -e "s|/__PRIMARY_DARK_COLOR_PLACEHOLDER__/|$PRIMARY_DARK_COLOR|g" \
     -e "s|/__INFLUXDB_TOKEN_PLACEHOLDER__/|$INFLUXDB_TOKEN|g" \

--- a/aas-web-ui/scripts/start-integration-runtime.sh
+++ b/aas-web-ui/scripts/start-integration-runtime.sh
@@ -49,6 +49,7 @@ if [ "$TARGET" = "preview" ]; then
   export VITE_LOGO_DARK_PATH="${VITE_LOGO_DARK_PATH:-Logo_dark.svg}"
   export VITE_PRIMARY_LIGHT_COLOR="${VITE_PRIMARY_LIGHT_COLOR:-#0cb2f0}"
   export VITE_PRIMARY_DARK_COLOR="${VITE_PRIMARY_DARK_COLOR:-#f69222}"
+  export VITE_ENDPOINT_CONFIG_AVAILABLE="${VITE_ENDPOINT_CONFIG_AVAILABLE:-true}"
 
   if [ "$LOGO_MODE" = "env" ]; then
     export VITE_LOGO_LIGHT_PATH="custom-logo.svg"

--- a/aas-web-ui/src/components/AppNavigation/Settings.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings.vue
@@ -3,6 +3,7 @@
     <template #activator="{ props }">
       <v-btn
         v-bind="props"
+        aria-label="Settings"
         icon
         size="small"
         style="padding-right: 28px; padding-left: 28px"

--- a/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureListTable.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureListTable.vue
@@ -43,6 +43,7 @@
             <td style="width: 120px">
               <div class="d-flex justify-end">
                 <v-btn
+                  :aria-label="`Edit ${infra.name}`"
                   icon="mdi-pencil"
                   size="x-small"
                   variant="plain"
@@ -50,6 +51,7 @@
                 />
 
                 <v-btn
+                  :aria-label="`Delete ${infra.name}`"
                   class="ml-n2 mr-n2"
                   :disabled="infrastructures.length === 1 || infra.isDefault"
                   icon="mdi-delete"

--- a/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureSelector.vue
+++ b/aas-web-ui/src/components/AppNavigation/Settings/InfrastructureSelector.vue
@@ -18,7 +18,13 @@
       </template>
 
       <template v-if="endpointConfigAvailable" #append>
-        <v-btn icon="mdi-cog" size="small" variant="text" @click="openManageDialog">
+        <v-btn
+          aria-label="Manage Infrastructures"
+          icon="mdi-cog"
+          size="small"
+          variant="text"
+          @click="openManageDialog"
+        >
           <v-icon>mdi-cog</v-icon>
           <v-tooltip activator="parent" location="bottom" :open-delay="600">Manage Infrastructures</v-tooltip>
         </v-btn>

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
@@ -322,6 +322,7 @@ export function useInfrastructureStorage (): {
       aasRepoPath?: string
       submodelRepoPath?: string
       conceptDescriptionRepoPath?: string
+      companyLookupPath?: string
       keycloakActive?: boolean
       keycloakUrl?: string
       keycloakRealm?: string
@@ -359,6 +360,9 @@ export function useInfrastructureStorage (): {
     }
     if (envConfig.conceptDescriptionRepoPath) {
       infrastructure.components.ConceptDescriptionRepo.url = envConfig.conceptDescriptionRepoPath
+    }
+    if (envConfig.companyLookupPath) {
+      infrastructure.components.CompanyLookup.url = envConfig.companyLookupPath
     }
 
     // Precedence logic: Keycloak takes precedence over generic OIDC if both are configured
@@ -463,6 +467,7 @@ export function useInfrastructureStorage (): {
     aasRepoPath?: string
     submodelRepoPath?: string
     conceptDescriptionRepoPath?: string
+    companyLookupPath?: string
     keycloakActive?: boolean
     keycloakUrl?: string
     keycloakRealm?: string
@@ -485,6 +490,7 @@ export function useInfrastructureStorage (): {
       || isNonEmptyUrl(envConfig.aasRepoPath)
       || isNonEmptyUrl(envConfig.submodelRepoPath)
       || isNonEmptyUrl(envConfig.conceptDescriptionRepoPath)
+      || isNonEmptyUrl(envConfig.companyLookupPath)
   }
 
   function matchesConfiguredUrl (expected?: string, actual?: string): boolean {
@@ -501,6 +507,7 @@ export function useInfrastructureStorage (): {
         envConfig.conceptDescriptionRepoPath,
         infra.components.ConceptDescriptionRepo.url,
       )
+      && matchesConfiguredUrl(envConfig.companyLookupPath, infra.components.CompanyLookup.url)
   }
 
   function hasKeycloakConfig (envConfig: MatchingEnvConfig): boolean {
@@ -740,6 +747,7 @@ export function useInfrastructureStorage (): {
       aasRepoPath?: string
       submodelRepoPath?: string
       conceptDescriptionRepoPath?: string
+      companyLookupPath?: string
       keycloakActive?: boolean
       keycloakUrl?: string
       keycloakRealm?: string

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
@@ -879,24 +879,30 @@ export function useInfrastructureStorage (): {
     try {
       // Check if environment variables are configured (backwards compatibility)
       // Environment variables take precedence over YAML to avoid breaking existing deployments
-      function isNonEmptyString (value: unknown): value is string {
-        return typeof value === 'string' && value.trim().length > 0
+      function isConfiguredString (value: unknown): value is string {
+        if (typeof value !== 'string') {
+          return false
+        }
+
+        const trimmedValue = value.trim()
+        return trimmedValue.length > 0
+          && !/^\/?__[A-Z0-9_]+_PLACEHOLDER__\/?$/.test(trimmedValue)
       }
 
       const hasEnvVars
-        = isNonEmptyString(envConfig.aasDiscoveryPath)
-          || isNonEmptyString(envConfig.aasRegistryPath)
-          || isNonEmptyString(envConfig.submodelRegistryPath)
-          || isNonEmptyString(envConfig.aasRepoPath)
-          || isNonEmptyString(envConfig.submodelRepoPath)
-          || isNonEmptyString(envConfig.conceptDescriptionRepoPath)
-          || isNonEmptyString(envConfig.companyLookupPath)
+        = isConfiguredString(envConfig.aasDiscoveryPath)
+          || isConfiguredString(envConfig.aasRegistryPath)
+          || isConfiguredString(envConfig.submodelRegistryPath)
+          || isConfiguredString(envConfig.aasRepoPath)
+          || isConfiguredString(envConfig.submodelRepoPath)
+          || isConfiguredString(envConfig.conceptDescriptionRepoPath)
+          || isConfiguredString(envConfig.companyLookupPath)
           || envConfig.keycloakActive === true
-          || (isNonEmptyString(envConfig.keycloakUrl)
-            && isNonEmptyString(envConfig.keycloakRealm)
-            && isNonEmptyString(envConfig.keycloakClientId))
+          || (isConfiguredString(envConfig.keycloakUrl)
+            && isConfiguredString(envConfig.keycloakRealm)
+            && isConfiguredString(envConfig.keycloakClientId))
           || envConfig.oidcActive === true
-          || (isNonEmptyString(envConfig.oidcUrl) && isNonEmptyString(envConfig.oidcClientId))
+          || (isConfiguredString(envConfig.oidcUrl) && isConfiguredString(envConfig.oidcClientId))
       // If environment variables are configured, use traditional configuration (backwards compatibility)
       if (hasEnvVars) {
         return await handleTraditionalConfiguration(envConfig, refreshTokensCallback)

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
@@ -81,6 +81,52 @@ describe('useInfrastructureStorage.ts', () => {
     expect(stored.infrastructures[0].template).toBe('full')
   })
 
+  it('creates an environment infrastructure with its Company Lookup endpoint', async () => {
+    const { createDefaultInfrastructureFromEnv } = useInfrastructureStorage()
+
+    const infrastructure = await createDefaultInfrastructureFromEnv({
+      companyLookupPath: 'https://company-lookup.example',
+    })
+
+    expect(infrastructure.components.CompanyLookup.url).toBe('https://company-lookup.example')
+  })
+
+  it('reuses a locked Company Lookup environment infrastructure from storage', async () => {
+    window.localStorage.setItem('basyxInfrastructures', JSON.stringify({
+      selectedInfrastructureId: 'stored-company-lookup',
+      infrastructures: [
+        {
+          id: 'stored-company-lookup',
+          name: 'Company Lookup',
+          template: 'full',
+          isDefault: true,
+          components: {
+            AASDiscovery: { url: '' },
+            AASRegistry: { url: '' },
+            SubmodelRegistry: { url: '' },
+            AASRepo: { url: '' },
+            SubmodelRepo: { url: '' },
+            ConceptDescriptionRepo: { url: '' },
+            CompanyLookup: { url: 'https://company-lookup.example' },
+          },
+          auth: { securityType: 'No Authentication' },
+          token: { accessToken: 'stored-token' },
+        },
+      ],
+    }))
+
+    const { loadInfrastructuresFromStorage } = useInfrastructureStorage()
+    const result = await loadInfrastructuresFromStorage({
+      companyLookupPath: 'https://company-lookup.example',
+      endpointConfigAvailable: false,
+    })
+
+    expect(result.selectedInfrastructureId).toBe('stored-company-lookup')
+    expect(result.infrastructures).toHaveLength(1)
+    expect(result.infrastructures[0].components.CompanyLookup.url).toBe('https://company-lookup.example')
+    expect(result.infrastructures[0].token?.accessToken).toBe('stored-token')
+  })
+
   it('ignores unresolved production placeholders when deciding whether env config overrides YAML', async () => {
     mockDeps.loadInfrastructureConfig.mockResolvedValue({
       infrastructures: [

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
@@ -81,6 +81,43 @@ describe('useInfrastructureStorage.ts', () => {
     expect(stored.infrastructures[0].template).toBe('full')
   })
 
+  it('ignores unresolved production placeholders when deciding whether env config overrides YAML', async () => {
+    mockDeps.loadInfrastructureConfig.mockResolvedValue({
+      infrastructures: [
+        {
+          id: 'yaml_production',
+          name: 'Production',
+          template: 'full',
+          components: {
+            AASDiscovery: { url: 'https://discovery.example' },
+            AASRegistry: { url: 'https://aas-registry.example' },
+            SubmodelRegistry: { url: 'https://submodel-registry.example' },
+            AASRepo: { url: 'https://aas-repository.example' },
+            SubmodelRepo: { url: 'https://submodel-repository.example' },
+            ConceptDescriptionRepo: { url: 'https://cd-repository.example' },
+            CompanyLookup: { url: 'https://company-lookup.example' },
+          },
+          auth: { securityType: 'No Authentication' },
+        },
+      ],
+      defaultInfrastructureId: 'yaml_production',
+    })
+
+    const { loadInfrastructuresFromStorage } = useInfrastructureStorage()
+    const result = await loadInfrastructuresFromStorage({
+      companyLookupPath: '/__COMPANY_LOOKUP_PATH_PLACEHOLDER__/',
+      endpointConfigAvailable: false,
+    })
+
+    expect(mockDeps.loadInfrastructureConfig).toHaveBeenCalledOnce()
+    expect(result.selectedInfrastructureId).toBe('yaml_production')
+    expect(result.infrastructures[0].components).toMatchObject({
+      AASDiscovery: { url: 'https://discovery.example' },
+      AASRepo: { url: 'https://aas-repository.example' },
+      CompanyLookup: { url: 'https://company-lookup.example' },
+    })
+  })
+
   it('persists Catena-X EDC proxy metadata only for Catena-X infrastructures', () => {
     const { saveInfrastructuresToStorage } = useInfrastructureStorage()
 

--- a/aas-web-ui/tests/integration/runtime-config.pw.ts
+++ b/aas-web-ui/tests/integration/runtime-config.pw.ts
@@ -55,6 +55,49 @@ test('infrastructure YAML endpoint is reachable under base path', async ({ reque
   expect(yamlBody).toContain('infrastructures:')
 })
 
+test('infrastructure YAML endpoints are loaded into the production UI', async ({ page }) => {
+  await page.goto(normalizedBasePath, { waitUntil: 'networkidle' })
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const stored = localStorage.getItem('basyxInfrastructures')
+      if (!stored) {
+        return null
+      }
+
+      const infrastructure = JSON.parse(stored).infrastructures?.[0]
+      return infrastructure
+        ? {
+            id: infrastructure.id,
+            name: infrastructure.name,
+            aasDiscovery: infrastructure.components?.AASDiscovery?.url,
+            aasRepository: infrastructure.components?.AASRepo?.url,
+            companyLookup: infrastructure.components?.CompanyLookup?.url,
+          }
+        : null
+    })
+  }).toEqual({
+    id: 'yaml_local',
+    name: 'Local BaSyx',
+    aasDiscovery: 'http://localhost:9084',
+    aasRepository: 'http://localhost:9081',
+    companyLookup: 'http://localhost:5080',
+  })
+
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await expect(page.getByRole('combobox', { name: 'Select Infrastructure' }))
+    .toHaveValue('Local BaSyx (Default)')
+  await page.getByRole('button', { name: 'Manage Infrastructures' }).click()
+  await page.getByRole('button', { name: 'Edit Local BaSyx' }).click()
+
+  await expect(page.getByRole('textbox', { name: 'AAS Discovery Endpoint URL' }))
+    .toHaveValue('http://localhost:9084')
+  await expect(page.getByRole('textbox', { name: 'AAS Repository Endpoint URL' }))
+    .toHaveValue('http://localhost:9081')
+  await expect(page.getByRole('textbox', { name: 'Company Lookup Endpoint URL' }))
+    .toHaveValue('http://localhost:5080')
+})
+
 test('custom logo via LOGO_PATH works under non-root base path', async ({ page, request }) => {
   test.skip(logoMode !== 'env', 'LOGO_PATH scenario only')
   test.skip(normalizedBasePath === '/', 'Custom non-root logo scenario requires a non-root base path')


### PR DESCRIPTION
## What changed

- fixed the Company Lookup runtime placeholder replacement in the Docker entrypoint
- propagated `COMPANY_LOOKUP_PATH` into environment-created infrastructures and locked-config matching
- ignored unresolved production placeholders when deciding whether environment configuration should override YAML
- added unit and production integration coverage for displaying preconfigured endpoints
- added accessible labels to the infrastructure settings actions used by the integration test

## Why

The Company Lookup placeholder emitted by the application did not match the placeholder replaced by the container entrypoint. The unresolved value was then treated as a configured environment endpoint. Since environment configuration takes precedence, the YAML loader was skipped and the infrastructure appeared without its configured endpoints.

The environment configuration path also did not copy `COMPANY_LOOKUP_PATH` into the generated infrastructure or include it when matching a locked infrastructure from browser storage.

## Validation

- `pnpm lint:check`
- `pnpm type-check`
- `pnpm test:run` (875 tests)
- production preview Playwright test
- fresh Docker image Playwright test with mounted `basyx-infra.yml`
