### PR TITLE
Fix default infrastructure selection from YAML

### DIFF
--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
@@ -630,9 +630,12 @@ export function useInfrastructureStorage (): {
           }
         }
 
+        const storedDefaultInfrastructureId
+          = storage.defaultInfrastructureId === undefined
+            ? storage.infrastructures.find(infra => infra.isDefault)?.id ?? null
+            : storage.defaultInfrastructureId
         const defaultInfrastructureUnchanged
-          = storage.defaultInfrastructureId !== undefined
-            && storage.defaultInfrastructureId === yamlConfig.defaultInfrastructureId
+          = storedDefaultInfrastructureId === yamlConfig.defaultInfrastructureId
 
         if (
           defaultInfrastructureUnchanged

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
@@ -630,8 +630,13 @@ export function useInfrastructureStorage (): {
           }
         }
 
+        const defaultInfrastructureUnchanged
+          = storage.defaultInfrastructureId !== undefined
+            && storage.defaultInfrastructureId === yamlConfig.defaultInfrastructureId
+
         if (
-          storage.selectedInfrastructureId
+          defaultInfrastructureUnchanged
+          && storage.selectedInfrastructureId
           && yamlConfig.infrastructures.some(infra => infra.id === storage.selectedInfrastructureId)
         ) {
           selectedId = storage.selectedInfrastructureId
@@ -949,6 +954,7 @@ export function useInfrastructureStorage (): {
       const storage: InfrastructureStorage = {
         infrastructures: infrastructures.map(infra => normalizeInfrastructureConfig(infra)),
         selectedInfrastructureId,
+        defaultInfrastructureId: infrastructures.find(infra => infra.isDefault)?.id ?? null,
       }
 
       localStorage.setItem('basyxInfrastructures', JSON.stringify(storage))

--- a/aas-web-ui/src/types/Infrastructure.ts
+++ b/aas-web-ui/src/types/Infrastructure.ts
@@ -129,6 +129,11 @@ export interface InfrastructureConfig {
 export interface InfrastructureStorage {
   infrastructures: InfrastructureConfig[]
   selectedInfrastructureId: string | null
+  /**
+   * Default infrastructure when this storage entry was written.
+   * Used to distinguish a changed configured default from a persisted user selection.
+   */
+  defaultInfrastructureId?: string | null
 }
 
 export type UserData = {

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
@@ -229,6 +229,30 @@ describe('useInfrastructureStorage.ts', () => {
     expect(result.selectedInfrastructureId).toBe(yamlFoo.id)
   })
 
+  it('preserves a legacy stored selection while the locked YAML default is unchanged', async () => {
+    const storedFoo = createInfrastructure('yaml_foo', false)
+    const storedBar = createInfrastructure('yaml_bar', true)
+
+    window.localStorage.setItem('basyxInfrastructures', JSON.stringify({
+      selectedInfrastructureId: storedFoo.id,
+      infrastructures: [storedFoo, storedBar],
+    }))
+
+    const yamlFoo = createInfrastructure('yaml_foo', false)
+    const yamlBar = createInfrastructure('yaml_bar', true)
+    mockDeps.loadInfrastructureConfig.mockResolvedValue({
+      infrastructures: [yamlFoo, yamlBar],
+      defaultInfrastructureId: yamlBar.id,
+    })
+
+    const { loadInfrastructuresFromStorage } = useInfrastructureStorage()
+    const result = await loadInfrastructuresFromStorage({
+      endpointConfigAvailable: false,
+    })
+
+    expect(result.selectedInfrastructureId).toBe(yamlFoo.id)
+  })
+
   it('persists Catena-X EDC proxy metadata only for Catena-X infrastructures', () => {
     const { saveInfrastructuresToStorage } = useInfrastructureStorage()
 

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
@@ -1,3 +1,4 @@
+import type { InfrastructureConfig } from '@/types/Infrastructure'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useInfrastructureStorage } from '@/composables/Infrastructure/useInfrastructureStorage'
 
@@ -22,6 +23,25 @@ vi.mock('@/store/NavigationStore', () => ({
 vi.mock('@/composables/Auth/OAuth2Auth', () => ({
   authenticateOAuth2ClientCredentials: mockDeps.authenticateOAuth2ClientCredentials,
 }))
+
+function createInfrastructure (id: string, isDefault: boolean): InfrastructureConfig {
+  return {
+    id,
+    name: id,
+    template: 'full',
+    isDefault,
+    components: {
+      AASDiscovery: { url: '' },
+      AASRegistry: { url: '' },
+      SubmodelRegistry: { url: '' },
+      AASRepo: { url: `https://${id}.example` },
+      SubmodelRepo: { url: '' },
+      ConceptDescriptionRepo: { url: '' },
+      CompanyLookup: { url: '' },
+    },
+    auth: { securityType: 'No Authentication' },
+  }
+}
 
 describe('useInfrastructureStorage.ts', () => {
   beforeEach(() => {
@@ -162,6 +182,51 @@ describe('useInfrastructureStorage.ts', () => {
       AASRepo: { url: 'https://aas-repository.example' },
       CompanyLookup: { url: 'https://company-lookup.example' },
     })
+  })
+
+  it('uses an updated default from a locked YAML configuration', async () => {
+    const storedFoo = createInfrastructure('yaml_foo', true)
+    const storedBar = createInfrastructure('yaml_bar', false)
+
+    window.localStorage.setItem('basyxInfrastructures', JSON.stringify({
+      selectedInfrastructureId: storedFoo.id,
+      infrastructures: [storedFoo, storedBar],
+    }))
+
+    const yamlFoo = createInfrastructure('yaml_foo', false)
+    const yamlBar = createInfrastructure('yaml_bar', true)
+    mockDeps.loadInfrastructureConfig.mockResolvedValue({
+      infrastructures: [yamlFoo, yamlBar],
+      defaultInfrastructureId: yamlBar.id,
+    })
+
+    const { loadInfrastructuresFromStorage } = useInfrastructureStorage()
+    const result = await loadInfrastructuresFromStorage({
+      endpointConfigAvailable: false,
+    })
+
+    expect(result.selectedInfrastructureId).toBe(yamlBar.id)
+  })
+
+  it('preserves a stored selection while the locked YAML default is unchanged', async () => {
+    const yamlFoo = createInfrastructure('yaml_foo', false)
+    const yamlBar = createInfrastructure('yaml_bar', true)
+    mockDeps.loadInfrastructureConfig.mockResolvedValue({
+      infrastructures: [yamlFoo, yamlBar],
+      defaultInfrastructureId: yamlBar.id,
+    })
+
+    const {
+      loadInfrastructuresFromStorage,
+      saveInfrastructuresToStorage,
+    } = useInfrastructureStorage()
+    saveInfrastructuresToStorage([yamlFoo, yamlBar], yamlFoo.id)
+
+    const result = await loadInfrastructuresFromStorage({
+      endpointConfigAvailable: false,
+    })
+
+    expect(result.selectedInfrastructureId).toBe(yamlFoo.id)
   })
 
   it('persists Catena-X EDC proxy metadata only for Catena-X infrastructures', () => {


### PR DESCRIPTION
## What changed

- track the configured default infrastructure together with the browser selection
- select an updated YAML default when the locked configuration changes
- preserve manual infrastructure selections while the YAML default stays unchanged
- add regression tests for both startup cases

## Why

With `ENDPOINT_CONFIG_AVAILABLE=false`, the selected infrastructure from `localStorage` unconditionally replaced the default from `basyx-infra.yml`. As a result, changing the configured default only took effect after clearing the browser storage.

Closes #1441

## Validation

- `pnpm lint:check`
- `pnpm type-check`
- `pnpm test:run` (969 tests)
