### PR TITLE
Module visibility authentication

### DIFF
--- a/aas-web-ui/src/components/AppNavigation/User.vue
+++ b/aas-web-ui/src/components/AppNavigation/User.vue
@@ -95,25 +95,7 @@
   })
 
   const isAuthenticated = computed(() => {
-    const infra = currentInfrastructure.value
-    if (!infra) return false
-
-    // Check if authenticated via token
-    if (infra.token?.accessToken && infra.isAuthenticated !== false) {
-      return true
-    }
-
-    // Check if authenticated via basic auth
-    if (infra.auth?.basicAuth) {
-      return true
-    }
-
-    // Check legacy isAuthenticated flag
-    if (infra.isAuthenticated) {
-      return true
-    }
-
-    return false
+    return infrastructureStore.getIsAuthenticated
   })
 
   const authStatus = computed(() => {

--- a/aas-web-ui/src/components/AppNavigation/User.vue
+++ b/aas-web-ui/src/components/AppNavigation/User.vue
@@ -102,27 +102,23 @@
     const infra = currentInfrastructure.value
     if (!infra) return 'Not Authenticated'
 
-    // Check if no authentication is configured
     if (!infra.auth || infra.auth.securityType === 'No Authentication') {
       return 'Authentication disabled'
     }
 
-    // Check if authenticated via token
-    if (infra.token?.accessToken && infra.isAuthenticated !== false) {
-      return 'Authenticated'
+    if (!isAuthenticated.value) {
+      return 'Not Authenticated'
     }
 
-    // Check if authenticated via basic auth
-    if (infra.auth?.basicAuth) {
+    if (infra.auth.securityType === 'Basic Authentication') {
       return 'Basic Authentication active'
     }
 
-    // Check legacy isAuthenticated flag
-    if (infra.isAuthenticated) {
-      return 'Authenticated'
+    if (infra.auth.securityType === 'Bearer Token') {
+      return 'Bearer Token active'
     }
 
-    return 'Not Authenticated'
+    return 'Authenticated'
   })
 
   const authStatusIcon = computed(() => {

--- a/aas-web-ui/src/components/AppNavigation/User.vue
+++ b/aas-web-ui/src/components/AppNavigation/User.vue
@@ -4,7 +4,7 @@
       <v-btn
         v-if="isAuthEnabled"
         v-bind="menuProps"
-        :icon="isAuthenticated ? 'mdi-account-lock' : 'mdi-lock-remove'"
+        :icon="hasAuthenticationCredentials ? 'mdi-account-lock' : 'mdi-lock-remove'"
         size="small"
         variant="tonal"
       />
@@ -25,7 +25,7 @@
       rounded="lg"
       style="border-style: solid; border-width: 1px"
     >
-      <v-list v-if="isAuthenticated" class="bg-navigationMenu" nav>
+      <v-list v-if="hasAuthenticationCredentials" class="bg-navigationMenu" nav>
         <v-list-item
           :active="false"
           class="py-2"
@@ -94,8 +94,8 @@
     return infrastructureStore.getSelectedInfrastructure
   })
 
-  const isAuthenticated = computed(() => {
-    return infrastructureStore.getIsAuthenticated
+  const hasAuthenticationCredentials = computed(() => {
+    return infrastructureStore.getHasAuthenticationCredentials
   })
 
   const authStatus = computed(() => {
@@ -106,7 +106,7 @@
       return 'Authentication disabled'
     }
 
-    if (!isAuthenticated.value) {
+    if (!hasAuthenticationCredentials.value) {
       return 'Not Authenticated'
     }
 

--- a/aas-web-ui/src/composables/ModuleHandling.ts
+++ b/aas-web-ui/src/composables/ModuleHandling.ts
@@ -79,7 +79,7 @@ export function useModuleHandling (): ModuleHandling {
 
   function matchesNeedsAuthentication (moduleRoute: ModuleNavigationRoute): boolean {
     const needsAuthentication = moduleRoute?.meta?.needsAuthentication
-    if (needsAuthentication && !infrastructureStore.getIsAuthenticated) {
+    if (needsAuthentication && !infrastructureStore.getHasAuthenticationCredentials) {
       return false
     }
     return true

--- a/aas-web-ui/src/composables/ModuleHandling.ts
+++ b/aas-web-ui/src/composables/ModuleHandling.ts
@@ -77,6 +77,14 @@ export function useModuleHandling (): ModuleHandling {
     return needsInfrastructureEndpoints.every(componentKey => infrastructureStore.isEndpointSet(componentKey))
   }
 
+  function matchesNeedsAuthentication (moduleRoute: ModuleNavigationRoute): boolean {
+    const needsAuthentication = moduleRoute?.meta?.needsAuthentication
+    if (needsAuthentication && !infrastructureStore.getIsAuthenticated) {
+      return false
+    }
+    return true
+  }
+
   function isModuleRouteVisible (
     moduleRoute: ModuleNavigationRoute,
     currentRouteName: string | undefined,
@@ -105,6 +113,9 @@ export function useModuleHandling (): ModuleHandling {
       return false
     }
     if (!matchesNeedsInfrastructureEndpoints(moduleRoute)) {
+      return false
+    }
+    if (!matchesNeedsAuthentication(moduleRoute)) {
       return false
     }
     return (

--- a/aas-web-ui/src/pages/modules/TestVisibleForEnvVariables.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleForEnvVariables.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container class="pa-md-12">
+    <v-empty-state
+      icon="mdi-folder-open-outline"
+      text="This is a test module to showcase how to extend the AAS Web UI with new modules."
+      :title="moduleName + ' Module'"
+    >
+      <template #media>
+        <v-icon size="64" />
+      </template>
+    </v-empty-state>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+
+  defineOptions({
+    inheritAttrs: false,
+    needsEnvVariables: ['SINGLE_AAS_REDIRECT', 'SINGLE_SM_REDIRECT'],
+  })
+
+  const moduleName = ref('TestVisibleForEnvVariables')
+</script>

--- a/aas-web-ui/src/pages/modules/TestVisibleForInfrastructureEndpoints.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleForInfrastructureEndpoints.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container class="pa-md-12">
+    <v-empty-state
+      icon="mdi-folder-open-outline"
+      text="This is a test module to showcase how to extend the AAS Web UI with new modules."
+      :title="moduleName + ' Module'"
+    >
+      <template #media>
+        <v-icon size="64" />
+      </template>
+    </v-empty-state>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+
+  defineOptions({
+    inheritAttrs: false,
+    needsInfrastructureEndpoints: ['AASRepo', 'SubmodelRepo'],
+  })
+
+  const moduleName = ref('TestVisibleForInfrastructureEndpoints')
+</script>

--- a/aas-web-ui/src/pages/modules/TestVisibleForSupportedInfrastructureTemplates.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleForSupportedInfrastructureTemplates.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container class="pa-md-12">
+    <v-empty-state
+      icon="mdi-folder-open-outline"
+      text="This is a test module to showcase how to extend the AAS Web UI with new modules."
+      :title="moduleName + ' Module'"
+    >
+      <template #media>
+        <v-icon size="64" />
+      </template>
+    </v-empty-state>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+
+  defineOptions({
+    inheritAttrs: false,
+    supportedInfrastructureTemplates: ['full', 'mono-repo'],
+  })
+
+  const moduleName = ref('TestVisibleForSupportedInfrastructureTemplates')
+</script>

--- a/aas-web-ui/src/pages/modules/TestVisibleOnAuthentication.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleOnAuthentication.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container class="pa-md-12">
+    <v-empty-state
+      icon="mdi-folder-open-outline"
+      text="This is a test module to showcase how to extend the AAS Web UI with new modules."
+      :title="moduleName + ' Module'"
+    >
+      <template #media>
+        <v-icon size="64" />
+      </template>
+    </v-empty-state>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+
+  defineOptions({
+    inheritAttrs: false,
+    needsAuthentication: true,
+  })
+
+  const moduleName = ref('TestVisibleOnRoutes')
+</script>

--- a/aas-web-ui/src/pages/modules/TestVisibleOnAuthentication.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleOnAuthentication.vue
@@ -20,5 +20,5 @@
     needsAuthentication: true,
   })
 
-  const moduleName = ref('TestVisibleOnRoutes')
+  const moduleName = ref('TestVisibleOnAuthentication')
 </script>

--- a/aas-web-ui/src/pages/modules/TestVisibleOnRoutes.vue
+++ b/aas-web-ui/src/pages/modules/TestVisibleOnRoutes.vue
@@ -20,5 +20,5 @@
     visibleOnRoutes: ['AASEditor', 'SMEditor'],
   })
 
-  const moduleName = ref('TestVisibleForRoutes')
+  const moduleName = ref('TestVisibleOnRoutes')
 </script>

--- a/aas-web-ui/src/router.ts
+++ b/aas-web-ui/src/router.ts
@@ -13,6 +13,7 @@ import {
   getOAuth2CallbackUri,
 } from '@/composables/Auth/OAuth2Navigation'
 import { discoverOpenIdConfiguration, oidcIssuersMatch } from '@/composables/Auth/OpenIdConnect'
+import { useAuth } from '@/composables/Auth/useAuth'
 import { watchFeatureControlRoutes } from '@/composables/FeatureControl'
 import { useRouteHandling } from '@/composables/routeHandling'
 import AASEditor from '@/pages/AASEditor.vue'
@@ -349,8 +350,14 @@ export async function createAppRouter (): Promise<Router> {
     history: createWebHistory(base),
     routes,
   })
+  const { showLoginRequiredSnackbar } = useAuth(router)
 
   let infrastructureInitializationEnsured = false
+
+  const lacksRequiredAuthenticationCredentials = (meta: Record<string, unknown>): boolean => {
+    return meta.needsAuthentication === true
+      && !infrastructureStore.getHasAuthenticationCredentials
+  }
 
   const tryResolveRouteByName = (name: string): RouteRecordRaw | undefined => {
     const direct = findRouteByName(routes, name)
@@ -389,6 +396,9 @@ export async function createAppRouter (): Promise<Router> {
     // Module constraints / visibility
     const meta = (record.meta || {}) as Record<string, unknown>
     if (meta.isVisibleModule === false) {
+      return 'AASViewer'
+    }
+    if (lacksRequiredAuthenticationCredentials(meta)) {
       return 'AASViewer'
     }
     if (
@@ -931,6 +941,11 @@ export async function createAppRouter (): Promise<Router> {
     if (to.path === '/' && from.matched.length === 0) {
       const startRouteName = resolveStartRouteName(to.query as Record<string, unknown>)
       return { name: startRouteName, query: to.query, replace: true }
+    }
+
+    if (lacksRequiredAuthenticationCredentials(to.meta)) {
+      showLoginRequiredSnackbar()
+      return { name: 'AASViewer', replace: true }
     }
 
     saveUrlQueryForSameRoute(to, from)

--- a/aas-web-ui/src/store/InfrastructureStore.ts
+++ b/aas-web-ui/src/store/InfrastructureStore.ts
@@ -219,22 +219,23 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
       return false
     }
 
-    // Check if authenticated via token
-    if (infra.token?.accessToken && infra.isAuthenticated !== false) {
-      return true
+    switch (infra.auth.securityType) {
+      case 'Basic Authentication': {
+        return Boolean(
+          infra.auth.basicAuth
+          && (infra.auth.basicAuth.username.trim() !== '' || infra.auth.basicAuth.password !== ''),
+        )
+      }
+      case 'Bearer Token': {
+        return Boolean(infra.auth.bearerToken?.token.trim())
+      }
+      case 'OAuth2': {
+        return Boolean(infra.token?.accessToken) && infra.isAuthenticated !== false
+      }
+      default: {
+        return false
+      }
     }
-
-    // Check if authenticated via basic auth
-    if (infra.auth?.basicAuth) {
-      return true
-    }
-
-    // Check legacy isAuthenticated flag
-    if (infra.isAuthenticated) {
-      return true
-    }
-
-    return false
   })
 
   function getDefaultInfrastructureId (): string {

--- a/aas-web-ui/src/store/InfrastructureStore.ts
+++ b/aas-web-ui/src/store/InfrastructureStore.ts
@@ -213,7 +213,7 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
     return (allowLogout || needsReauthentication) && !isOAuth2ClientCredentials
   })
 
-  const getIsAuthenticated = computed(() => {
+  const getHasAuthenticationCredentials = computed(() => {
     const infra = getSelectedInfrastructure.value
     if (!infra || !infra.auth || infra.auth.securityType === 'No Authentication') {
       return false
@@ -743,7 +743,7 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
     getIsAuthenticating,
     getIsTestingConnections,
     getIsLoginAvailable,
-    getIsAuthenticated,
+    getHasAuthenticationCredentials,
 
     // Actions
     isEndpointSet,

--- a/aas-web-ui/src/store/InfrastructureStore.ts
+++ b/aas-web-ui/src/store/InfrastructureStore.ts
@@ -213,6 +213,30 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
     return (allowLogout || needsReauthentication) && !isOAuth2ClientCredentials
   })
 
+  const getIsAuthenticated = computed(() => {
+    const infra = getSelectedInfrastructure.value
+    if (!infra || !infra.auth || infra.auth.securityType === 'No Authentication') {
+      return false
+    }
+
+    // Check if authenticated via token
+    if (infra.token?.accessToken && infra.isAuthenticated !== false) {
+      return true
+    }
+
+    // Check if authenticated via basic auth
+    if (infra.auth?.basicAuth) {
+      return true
+    }
+
+    // Check legacy isAuthenticated flag
+    if (infra.isAuthenticated) {
+      return true
+    }
+
+    return false
+  })
+
   function getDefaultInfrastructureId (): string {
     // Look for infrastructure marked as default
     const defaultInfra = infrastructures.value.find(infra => infra.isDefault)
@@ -718,6 +742,7 @@ export const useInfrastructureStore = defineStore('infrastructureStore', () => {
     getIsAuthenticating,
     getIsTestingConnections,
     getIsLoginAvailable,
+    getIsAuthenticated,
 
     // Actions
     isEndpointSet,

--- a/aas-web-ui/src/types/Application.ts
+++ b/aas-web-ui/src/types/Application.ts
@@ -68,6 +68,7 @@ export interface ModuleNavigationRouteMeta {
   needsEnvVariables?: Array<string>
   needsInfrastructureEndpoints?: Array<BaSyxComponentKey>
   supportedInfrastructureTemplates?: InfrastructureTemplate[]
+  needsAuthentication?: boolean
   preserveRouteQuery?: boolean
 }
 

--- a/aas-web-ui/src/utils/ModuleRouteUtils.ts
+++ b/aas-web-ui/src/utils/ModuleRouteUtils.ts
@@ -17,6 +17,7 @@ export type ModuleRouteMeta = {
   preserveRouteQuery?: boolean
   needsInfrastructureEndpoints?: Array<BaSyxComponentKey>
   needsEnvVariables?: Array<string>
+  needsAuthentication?: boolean
 }
 
 export type ModuleChildRouteDefinition = {
@@ -55,6 +56,7 @@ export function buildModuleRouteMeta (
     supportedInfrastructureTemplates: moduleOptions?.supportedInfrastructureTemplates ?? [],
     needsInfrastructureEndpoints: moduleOptions?.needsInfrastructureEndpoints ?? [],
     needsEnvVariables: moduleOptions?.needsEnvVariables ?? [],
+    needsAuthentication: moduleOptions?.needsAuthentication ?? false,
     preserveRouteQuery,
   }
 }
@@ -140,6 +142,7 @@ export function buildValidatedModuleChildRoutes (moduleName: string,
                       : parentMeta.preserveRouteQuery,
         needsInfrastructureEndpoints: parentMeta.needsInfrastructureEndpoints,
         needsEnvVariables: parentMeta.needsEnvVariables,
+        needsAuthentication: parentMeta.needsAuthentication,
       },
       component: childRouteDefinition.component,
     }

--- a/aas-web-ui/tests/composables/ModuleHandling.test.ts
+++ b/aas-web-ui/tests/composables/ModuleHandling.test.ts
@@ -22,7 +22,7 @@ const mockState = {
   selectedInfrastructure: ref<{ template: string } | null>({ template: 'full' }),
   setEnvVariables: ref<Array<string>>([]),
   setInfrastructureEndpoints: ref<Array<string>>([]),
-  isAuthenticated: ref(false),
+  hasAuthenticationCredentials: ref(false),
 }
 
 async function importUseModuleHandling () {
@@ -62,8 +62,8 @@ async function importUseModuleHandling () {
         return mockState.selectedInfrastructure.value
       },
       isEndpointSet: (componentKey: string) => mockState.setInfrastructureEndpoints.value.includes(componentKey),
-      get getIsAuthenticated () {
-        return mockState.isAuthenticated.value
+      get getHasAuthenticationCredentials () {
+        return mockState.hasAuthenticationCredentials.value
       },
     }),
   }))
@@ -89,7 +89,7 @@ describe('ModuleHandling.ts', () => {
     mockState.selectedInfrastructure.value = { template: 'full' }
     mockState.setEnvVariables.value = []
     mockState.setInfrastructureEndpoints.value = []
-    mockState.isAuthenticated.value = false
+    mockState.hasAuthenticationCredentials.value = false
     mockState.moduleRoutes.value = [
       createModuleRoute({
         path: '/modules/test-module',
@@ -304,7 +304,7 @@ describe('ModuleHandling.ts', () => {
   })
 
   it('excludes a module when needsAuthentication is true and user is not authenticated', async () => {
-    mockState.isAuthenticated.value = false
+    mockState.hasAuthenticationCredentials.value = false
     mockState.moduleRoutes.value = [
       createModuleRoute({
         path: '/modules/needs-auth',
@@ -326,7 +326,7 @@ describe('ModuleHandling.ts', () => {
   })
 
   it('includes a module when needsAuthentication is true and user is authenticated', async () => {
-    mockState.isAuthenticated.value = true
+    mockState.hasAuthenticationCredentials.value = true
     mockState.moduleRoutes.value = [
       createModuleRoute({
         path: '/modules/needs-auth',
@@ -349,7 +349,7 @@ describe('ModuleHandling.ts', () => {
   })
 
   it('includes a module when needsAuthentication is not set regardless of authentication state', async () => {
-    mockState.isAuthenticated.value = false
+    mockState.hasAuthenticationCredentials.value = false
     mockState.moduleRoutes.value = [
       createModuleRoute({
         path: '/modules/no-auth-requirement',

--- a/aas-web-ui/tests/composables/ModuleHandling.test.ts
+++ b/aas-web-ui/tests/composables/ModuleHandling.test.ts
@@ -22,6 +22,7 @@ const mockState = {
   selectedInfrastructure: ref<{ template: string } | null>({ template: 'full' }),
   setEnvVariables: ref<Array<string>>([]),
   setInfrastructureEndpoints: ref<Array<string>>([]),
+  isAuthenticated: ref(false),
 }
 
 async function importUseModuleHandling () {
@@ -61,6 +62,9 @@ async function importUseModuleHandling () {
         return mockState.selectedInfrastructure.value
       },
       isEndpointSet: (componentKey: string) => mockState.setInfrastructureEndpoints.value.includes(componentKey),
+      get getIsAuthenticated () {
+        return mockState.isAuthenticated.value
+      },
     }),
   }))
 
@@ -85,6 +89,7 @@ describe('ModuleHandling.ts', () => {
     mockState.selectedInfrastructure.value = { template: 'full' }
     mockState.setEnvVariables.value = []
     mockState.setInfrastructureEndpoints.value = []
+    mockState.isAuthenticated.value = false
     mockState.moduleRoutes.value = [
       createModuleRoute({
         path: '/modules/test-module',
@@ -296,6 +301,73 @@ describe('ModuleHandling.ts', () => {
 
     expect(filteredRoutes).toHaveLength(1)
     expect(filteredRoutes[0].name).toBe('BaSyxComponentEndpointModule')
+  })
+
+  it('excludes a module when needsAuthentication is true and user is not authenticated', async () => {
+    mockState.isAuthenticated.value = false
+    mockState.moduleRoutes.value = [
+      createModuleRoute({
+        path: '/modules/needs-auth',
+        name: 'NeedsAuthModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+          needsAuthentication: true,
+        },
+      }),
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(0)
+  })
+
+  it('includes a module when needsAuthentication is true and user is authenticated', async () => {
+    mockState.isAuthenticated.value = true
+    mockState.moduleRoutes.value = [
+      createModuleRoute({
+        path: '/modules/needs-auth',
+        name: 'NeedsAuthModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+          needsAuthentication: true,
+        },
+      }),
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(1)
+    expect(filteredRoutes[0].name).toBe('NeedsAuthModule')
+  })
+
+  it('includes a module when needsAuthentication is not set regardless of authentication state', async () => {
+    mockState.isAuthenticated.value = false
+    mockState.moduleRoutes.value = [
+      createModuleRoute({
+        path: '/modules/no-auth-requirement',
+        name: 'NoAuthRequirementModule',
+        meta: {
+          isDesktopModule: true,
+          isMobileModule: true,
+          isVisibleModule: true,
+        },
+      }),
+    ]
+
+    const { useModuleHandling } = await importUseModuleHandling()
+    const { determineFilteredAndOrderedModuleRoutes } = useModuleHandling()
+    const filteredRoutes = determineFilteredAndOrderedModuleRoutes()
+
+    expect(filteredRoutes).toHaveLength(1)
+    expect(filteredRoutes[0].name).toBe('NoAuthRequirementModule')
   })
 
   it('reacts to route name and store changes when wrapped in computed by callers', async () => {

--- a/aas-web-ui/tests/router/OAuth2CallbackRouting.test.ts
+++ b/aas-web-ui/tests/router/OAuth2CallbackRouting.test.ts
@@ -36,6 +36,7 @@ const mockDeps = vi.hoisted(() => ({
   infrastructureStore: {
     getInfrastructures: [] as Array<any>,
     getSelectedInfrastructure: null as any,
+    getHasAuthenticationCredentials: true,
     getIsLoginAvailable: true,
     waitForInitialization: vi.fn(),
     dispatchUpdateInfrastructure: vi.fn(),
@@ -106,6 +107,7 @@ describe('OAuth2 callback routing', () => {
 
     mockDeps.infrastructureStore.getInfrastructures = [mockDeps.infrastructure]
     mockDeps.infrastructureStore.getSelectedInfrastructure = mockDeps.infrastructure
+    mockDeps.infrastructureStore.getHasAuthenticationCredentials = true
     mockDeps.infrastructure.auth.oauth2.host = 'https://idp.example'
     mockDeps.infrastructureStore.waitForInitialization.mockResolvedValue(undefined)
     mockDeps.aasStore.getSelectedAAS = {}
@@ -113,6 +115,7 @@ describe('OAuth2 callback routing', () => {
     mockDeps.navigationStore.getRouteTransition = null
     mockDeps.envStore.getSingleAas = true
     mockDeps.envStore.getSingleSm = false
+    mockDeps.envStore.getStartPageRouteName = ''
     mockDeps.exchangeOAuth2AuthorizationCode.mockResolvedValue({
       accessToken: 'access-token',
       refreshToken: 'refresh-token',
@@ -237,6 +240,42 @@ describe('OAuth2 callback routing', () => {
 
     expect(router.currentRoute.value.name).toBe('SMViewer')
     expect(router.currentRoute.value.query).not.toHaveProperty('path')
+  })
+
+  it('redirects direct navigation to an authentication-required module', async () => {
+    mockDeps.infrastructureStore.getHasAuthenticationCredentials = false
+    mockDeps.envStore.getSingleAas = false
+    const router = await createAppRouter()
+
+    await router.push('/modules/testvisibleonauthentication')
+
+    expect(router.currentRoute.value.name).toBe('AASViewer')
+    expect(mockDeps.navigationStore.dispatchSnackbar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseError: 'Authentication required!',
+        kind: 'authentication-required',
+      }),
+    )
+  })
+
+  it('allows direct navigation to an authentication-required module with credentials', async () => {
+    const router = await createAppRouter()
+
+    await router.push('/modules/testvisibleonauthentication')
+
+    expect(router.currentRoute.value.name).toBe('TestVisibleOnAuthentication')
+  })
+
+  it('does not use an authentication-required module as the unauthenticated start route', async () => {
+    mockDeps.infrastructureStore.getHasAuthenticationCredentials = false
+    mockDeps.envStore.getSingleAas = false
+    mockDeps.envStore.getStartPageRouteName = 'TestVisibleOnAuthentication'
+    window.history.replaceState({}, '', '/')
+    const router = await createAppRouter()
+
+    await router.push('/')
+
+    expect(router.currentRoute.value.name).toBe('AASViewer')
   })
 
   it('rejects an issuer injected into the authorization response', async () => {

--- a/aas-web-ui/tests/router/moduleRouteManifest.test.ts
+++ b/aas-web-ui/tests/router/moduleRouteManifest.test.ts
@@ -26,6 +26,7 @@ describe('module manifest child routes', () => {
         isOnlyVisibleWithSelectedNode: false,
         needsInfrastructureEndpoints: ['CompanyLookup'],
         needsEnvVariables: ['COMPANY_LOOKUP_DOMAIN'],
+        needsAuthentication: true,
         supportedInfrastructureTemplates: ['full', 'mono-all'],
         preserveRouteQuery: true,
       },
@@ -47,6 +48,7 @@ describe('module manifest child routes', () => {
     expect(children[0].meta?.isOnlyVisibleWithSelectedAas).toBe(true)
     expect(children[0].meta?.needsInfrastructureEndpoints).toEqual(['CompanyLookup'])
     expect(children[0].meta?.needsEnvVariables).toEqual(['COMPANY_LOOKUP_DOMAIN'])
+    expect(children[0].meta?.needsAuthentication).toBe(true)
     expect(children[0].meta?.supportedInfrastructureTemplates).toEqual(['full', 'mono-all'])
     expect(children[0].meta?.preserveRouteQuery).toBe(true)
   })

--- a/aas-web-ui/tests/store/InfrastructureStoreFeatureControl.test.ts
+++ b/aas-web-ui/tests/store/InfrastructureStoreFeatureControl.test.ts
@@ -244,7 +244,7 @@ describe('InfrastructureStore', () => {
         isAuthenticated: scenario.isAuthenticated,
       })
 
-      expect(store.getIsAuthenticated, scenario.name).toBe(scenario.expected)
+      expect(store.getHasAuthenticationCredentials, scenario.name).toBe(scenario.expected)
     }
   })
 })

--- a/aas-web-ui/tests/store/InfrastructureStoreFeatureControl.test.ts
+++ b/aas-web-ui/tests/store/InfrastructureStoreFeatureControl.test.ts
@@ -110,7 +110,7 @@ function infrastructure (id: string, features: string[]): InfrastructureConfig {
   }
 }
 
-describe('InfrastructureStore feature-control lifecycle', () => {
+describe('InfrastructureStore', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.appliedOverrides.length = 0
@@ -148,5 +148,103 @@ describe('InfrastructureStore feature-control lifecycle', () => {
     store.dispatchUpdateInfrastructure({ ...store.getSelectedInfrastructure!, token: undefined })
     await nextTick()
     expect(mocks.appliedOverrides.at(-1)).toBeNull()
+  })
+
+  it('derives authentication from credentials for the active security type only', async () => {
+    const store = useInfrastructureStore()
+    await store.waitForInitialization()
+
+    const selectedInfrastructure = store.getSelectedInfrastructure!
+    const scenarios: Array<{
+      name: string
+      auth: InfrastructureConfig['auth']
+      token?: InfrastructureConfig['token']
+      isAuthenticated?: boolean
+      expected: boolean
+    }> = [
+      {
+        name: 'no authentication ignores stale credentials and state',
+        auth: {
+          securityType: 'No Authentication',
+          basicAuth: { username: 'stale-user', password: 'stale-password' },
+        },
+        token: { accessToken: 'stale-token' },
+        isAuthenticated: true,
+        expected: false,
+      },
+      {
+        name: 'basic authentication accepts configured credentials',
+        auth: {
+          securityType: 'Basic Authentication',
+          basicAuth: { username: 'user', password: '' },
+        },
+        expected: true,
+      },
+      {
+        name: 'basic authentication rejects empty credentials',
+        auth: {
+          securityType: 'Basic Authentication',
+          basicAuth: { username: '', password: '' },
+        },
+        expected: false,
+      },
+      {
+        name: 'bearer authentication accepts a configured token',
+        auth: {
+          securityType: 'Bearer Token',
+          bearerToken: { token: 'static-token' },
+        },
+        expected: true,
+      },
+      {
+        name: 'bearer authentication ignores stale basic credentials',
+        auth: {
+          securityType: 'Bearer Token',
+          basicAuth: { username: 'stale-user', password: 'stale-password' },
+          bearerToken: { token: ' '.repeat(3) },
+        },
+        expected: false,
+      },
+      {
+        name: 'OAuth2 accepts a valid runtime token',
+        auth: {
+          securityType: 'OAuth2',
+          oauth2: { host: 'https://idp.example', clientId: 'ui' },
+        },
+        token: { accessToken: 'oauth-token' },
+        expected: true,
+      },
+      {
+        name: 'OAuth2 rejects an invalidated runtime token',
+        auth: {
+          securityType: 'OAuth2',
+          oauth2: { host: 'https://idp.example', clientId: 'ui' },
+        },
+        token: { accessToken: 'oauth-token' },
+        isAuthenticated: false,
+        expected: false,
+      },
+      {
+        name: 'OAuth2 ignores stale credentials and authentication state without a token',
+        auth: {
+          securityType: 'OAuth2',
+          basicAuth: { username: 'stale-user', password: 'stale-password' },
+          oauth2: { host: 'https://idp.example', clientId: 'ui' },
+        },
+        isAuthenticated: true,
+        expected: false,
+      },
+    ]
+
+    for (const scenario of scenarios) {
+      store.dispatchUpdateInfrastructure({
+        ...selectedInfrastructure,
+        auth: scenario.auth,
+        token: scenario.token,
+        isAuthenticated: scenario.isAuthenticated,
+      })
+
+      expect(store.getIsAuthenticated, scenario.name).toBe(scenario.expected)
+    }
   })
 })


### PR DESCRIPTION
## Description of Changes

This PR introduces a `needsAuthentication` module visibility criterion, allowing modules to declare that they should only be shown in navigation when the user is authenticated against the currently selected infrastructure. It also adds test/demo modules to showcase the various existing module visibility mechanisms.

## Changes
- Centralized authentication check: Moved the "is user authenticated" logic out of `User.vue` and into a new `getIsAuthenticated` computed property on `InfrastructureStore`. This avoids duplicating the token/basic-auth/legacy-flag checks and makes the authentication state reusable across the app.
- New module visibility criterion: Added `needsAuthentication` to `ModuleNavigationRouteMeta` / `ModuleRouteMeta`, propagated through `buildModuleRouteMeta` and `buildValidatedModuleChildRoutes` in `ModuleRouteUtils.ts`.
- `ModuleHandling` composable: Added `matchesNeedsAuthentication` check, wired into `isModuleRouteVisible`, so a module route with `needsAuthentication: true` is hidden from navigation unless `infrastructureStore.getIsAuthenticated` is `true`.
- `User.vue`: Simplified `isAuthenticated` to delegate to `infrastructureStore.getIsAuthenticated`.
- Demo/test modules: Added example pages under `src/pages/modules/` demonstrating each visibility mechanism:
  - `TestVisibleForEnvVariables.vue`
  - `TestVisibleForInfrastructureEndpoints.vue`
  - `TestVisibleForSupportedInfrastructureTemplates.vue`
  - `TestVisibleOnAuthentication.vue`
  - Renamed `TestVisibleForRoutes.vue` → `TestVisibleOnRoutes.vue` for naming consistency.
- Tests: Added unit tests in `ModuleHandling.test.ts` covering the new authentication-based visibility logic.

## Testing
- Added/extended unit tests for `ModuleHandling` composable.
- Manually verified module visibility toggles correctly when authenticating/logging out against a configured infrastructure.