### PR TITLE
fix: prevent legacy default partner from overwriting configured Catena-X partner data

### DIFF
--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureStorage.ts
@@ -228,10 +228,10 @@ export function useInfrastructureStorage (): {
 
     const legacyDefaultPartner = createLegacyDefaultPartner(edc?.defaultCounterPartyId, edc?.defaultCounterPartyAddress)
     const partners = normalizeCatenaXPartners([
-      ...(edc?.partners ?? []),
       ...(legacyDefaultPartner ? [legacyDefaultPartner] : []),
+      ...(edc?.partners ?? []),
     ])
-    const defaultPartnerId = edc?.defaultPartnerId?.trim() || partners[0]?.id
+    const defaultPartnerId = edc?.defaultPartnerId?.trim() || partners[0]?.id?.trim()
     const defaultPartner = partners.find(partner => partner.id === defaultPartnerId) ?? partners[0]
 
     infrastructure.catenaX = {

--- a/aas-web-ui/src/composables/Infrastructure/useInfrastructureYamlParser.ts
+++ b/aas-web-ui/src/composables/Infrastructure/useInfrastructureYamlParser.ts
@@ -200,8 +200,8 @@ export function useInfrastructureYamlParser (): {
 
     return Array.from(
       new Map([
-        ...(partners ?? []),
         ...(legacyDefaultPartner ? [legacyDefaultPartner] : []),
+        ...(partners ?? []),
       ].map(partner => [`${partner.counterPartyId}::${partner.counterPartyAddress}`, partner])).values(),
     )
   }

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureStorage.test.ts
@@ -318,4 +318,57 @@ describe('useInfrastructureStorage.ts', () => {
     })
     expect(stored.infrastructures[1].catenaX).toBeUndefined()
   })
+
+  it('preserves configured partner metadata when it matches the legacy default', () => {
+    const { saveInfrastructuresToStorage } = useInfrastructureStorage()
+    const infrastructure = createInfrastructure('catena-x', true)
+    infrastructure.template = 'catena-x'
+    infrastructure.catenaX = {
+      accessMode: 'edc',
+      edc: {
+        proxyId: 'default',
+        defaultPartnerId: 'partner-a',
+        defaultCounterPartyId: 'BPNL000000000AAA',
+        defaultCounterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+        partners: [
+          {
+            id: 'partner-a',
+            name: 'Partner A',
+            counterPartyId: 'BPNL000000000AAA',
+            counterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+          },
+          {
+            id: 'partner-b',
+            name: 'Partner B',
+            counterPartyId: 'BPNL000000000BBB',
+            counterPartyAddress: 'https://partner-b.example/api/v1/dsp',
+          },
+        ],
+      },
+    }
+
+    saveInfrastructuresToStorage([infrastructure], infrastructure.id)
+
+    const stored = JSON.parse(window.localStorage.getItem('basyxInfrastructures') ?? '{}')
+    expect(stored.infrastructures[0].catenaX.edc).toEqual({
+      proxyId: 'default',
+      defaultPartnerId: 'partner-a',
+      defaultCounterPartyId: 'BPNL000000000AAA',
+      defaultCounterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+      partners: [
+        {
+          id: 'partner-a',
+          name: 'Partner A',
+          counterPartyId: 'BPNL000000000AAA',
+          counterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+        },
+        {
+          id: 'partner-b',
+          name: 'Partner B',
+          counterPartyId: 'BPNL000000000BBB',
+          counterPartyAddress: 'https://partner-b.example/api/v1/dsp',
+        },
+      ],
+    })
+  })
 })

--- a/aas-web-ui/tests/composables/Infrastructure/useInfrastructureYamlParser.test.ts
+++ b/aas-web-ui/tests/composables/Infrastructure/useInfrastructureYamlParser.test.ts
@@ -191,4 +191,59 @@ describe('useInfrastructureYamlParser.ts', () => {
       ],
     })
   })
+
+  it('preserves configured partner metadata when it matches the legacy default', () => {
+    const { parseYamlConfig } = useInfrastructureYamlParser()
+
+    const parsed = parseYamlConfig(createYamlConfig({
+      name: 'Catena-X',
+      template: 'catena-x',
+      components: {},
+      catenaX: {
+        accessMode: 'edc',
+        edc: {
+          proxyId: 'default',
+          defaultPartnerId: 'partner-a',
+          defaultCounterPartyId: 'BPNL000000000AAA',
+          defaultCounterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+          partners: [
+            {
+              id: 'partner-a',
+              name: 'Partner A',
+              counterPartyId: 'BPNL000000000AAA',
+              counterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+            },
+            {
+              id: 'partner-b',
+              name: 'Partner B',
+              counterPartyId: 'BPNL000000000BBB',
+              counterPartyAddress: 'https://partner-b.example/api/v1/dsp',
+            },
+          ],
+        },
+      },
+      security: { type: 'none' },
+    }))
+
+    expect(parsed.infrastructures[0].catenaX?.edc).toEqual({
+      proxyId: 'default',
+      defaultPartnerId: 'partner-a',
+      defaultCounterPartyId: 'BPNL000000000AAA',
+      defaultCounterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+      partners: [
+        {
+          id: 'partner-a',
+          name: 'Partner A',
+          counterPartyId: 'BPNL000000000AAA',
+          counterPartyAddress: 'https://partner-a.example/api/v1/dsp',
+        },
+        {
+          id: 'partner-b',
+          name: 'Partner B',
+          counterPartyId: 'BPNL000000000BBB',
+          counterPartyAddress: 'https://partner-b.example/api/v1/dsp',
+        },
+      ],
+    })
+  })
 })


### PR DESCRIPTION
## Description of Changes

### Bug

When a Catena-X infrastructure defines both a `defaultPartnerId`/`defaultCounterPartyId`/`defaultCounterPartyAddress` pair and a full `partners` list, the partner matching the default connection loses its configured `id` and `name`.

For example, with this configuration:

```yaml
catenaX:
  edc:
    defaultPartnerId: partnerA
    defaultCounterPartyAddress: "https://partner-a.example.com/api/v1/dsp"
    defaultCounterPartyId: "did:web:ssi.sandbox.example.org:BPNL000000000AAA"
    partners:
      - id: partnerA
        name: Partner A
        counterPartyId: "did:web:ssi.sandbox.example.org:BPNL000000000AAA"
        counterPartyAddress: "https://partner-a.example.com/api/v1/dsp"
      - id: partnerB
        name: Partner B
        ...
```

`normalizeCatenaXPartners` returned:

```json
[
  {
    "id": "did-web-ssi-sandbox-example-org-bpnl000000000aaa-https-partner-a-example-com-api-v1-dsp",
    "counterPartyId": "did:web:ssi.sandbox.example.org:BPNL000000000AAA",
    "counterPartyAddress": "https://partner-a.example.com/api/v1/dsp"
  },
  { "id": "partnerB", "name": "Partner B", ... }
]
```

The `partnerA` entry's `id` and `name` were missing/replaced with an auto-generated slug ID.

### Root Cause

Both `normalizeCatenaXConfig` (`useInfrastructureStorage.ts`) and `parseCatenaXPartners` (`useInfrastructureYamlParser.ts`) synthesize a "legacy default partner" from `defaultCounterPartyId`/`defaultCounterPartyAddress` for backward compatibility, then merge it with the real `partners` array before deduplicating by key (`counterPartyId::counterPartyAddress`) using a `Map`.

Since a `Map` keeps the **last** entry for a duplicate key, and the legacy partner was appended **after** the configured partners in the merge array, it silently overwrote the matching configured partner — replacing its proper `id`/`name` with the auto-generated fallback values.

### Fix

Reordered the merge so the synthesized legacy partner comes **first** and any configured partner sharing the same `counterPartyId`/`counterPartyAddress` overwrites it during deduplication, instead of the reverse. Applied the same fix in both:

- `useInfrastructureStorage.ts` (`normalizeCatenaXConfig`)
- `useInfrastructureYamlParser.ts` (`parseCatenaXPartners`)

Also hardened `defaultPartnerId` fallback in `useInfrastructureStorage.ts` to trim the fallback partner ID consistently.

## Related Issue

N/A

## BaSyx Configuration for Testing

A `catena-x` template infrastructure with an EDC `partners` list where `defaultPartnerId` matches one of the configured partners (same `counterPartyId`/`counterPartyAddress`), e.g.:

```yaml
catenaX:
  accessMode: edc
  edc:
    proxyId: default
    defaultPartnerId: partnerA
    defaultCounterPartyAddress: "https://partner-a.example.com/api/v1/dsp"
    defaultCounterPartyId: "did:web:ssi.sandbox.example.org:BPNL000000000AAA"
    partners:
      - id: partnerA
        name: Partner A
        counterPartyId: "did:web:ssi.sandbox.example.org:BPNL000000000AAA"
        counterPartyAddress: "https://partner-a.example.com/api/v1/dsp"
      - id: partnerB
        name: Partner B
        counterPartyId: "did:web:ssi.sandbox.example.org:BPNL000000000BBB"
        counterPartyAddress: "https://partner-b.example.com/api/v1/dsp"
```

## AAS Files Used for Testing

Not applicable — this fix is scoped to Catena-X infrastructure partner normalization and does not involve AAS/Submodel content.

## Additional Information

Verified with a Catena-X infrastructure config that the default partner now retains its configured `id` and `name` instead of falling back to an auto-generated ID derived from `counterPartyId`/`counterPartyAddress`.