### PR TITLE
Fix warnings in unit tests

### DIFF
--- a/aas-web-ui/src/components/Plugins/Submodels/TimeSeries/AutoRefreshSelector.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/TimeSeries/AutoRefreshSelector.vue
@@ -43,7 +43,7 @@
           label="Auto refresh"
         />
 
-        <v-row dense>
+        <v-row density="compact">
           <v-col cols="7">
             <div class="text-caption mb-1">Refresh every</div>
 

--- a/aas-web-ui/src/components/Plugins/Submodels/TimeSeries/TimeRangeSelector.vue
+++ b/aas-web-ui/src/components/Plugins/Submodels/TimeSeries/TimeRangeSelector.vue
@@ -48,7 +48,7 @@
         </v-btn-toggle>
 
         <template v-if="mode === 'relative'">
-          <v-row class="mb-2" dense>
+          <v-row class="mb-2" density="compact">
             <v-col v-for="preset in presets" :key="preset.id" cols="3">
               <v-btn
                 :active="selectedPreset === preset.id"
@@ -64,7 +64,7 @@
             </v-col>
           </v-row>
 
-          <v-row v-if="selectedPreset === 'custom'" dense>
+          <v-row v-if="selectedPreset === 'custom'" density="compact">
             <v-col cols="7">
               <div class="text-caption mb-1">Range</div>
 
@@ -83,7 +83,7 @@
             <v-col cols="5">
               <div class="text-caption mb-1">Unit</div>
 
-              <v-row dense>
+              <v-row density="compact">
                 <v-col v-for="unit in relativeUnits" :key="unit.value" cols="3">
                   <v-btn
                     :active="relativeUnit === unit.value"

--- a/aas-web-ui/tests/components/Code/CodeViewer.test.ts
+++ b/aas-web-ui/tests/components/Code/CodeViewer.test.ts
@@ -2,6 +2,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import CodeViewer from '@/components/Code/CodeViewer.vue'
+import { hotkeyStub } from '../../helpers/vuetifyStubs'
 
 const editor = defineComponent({
   props: { modelValue: String, readOnly: Boolean, options: Object },
@@ -18,7 +19,7 @@ const stubs = {
   VSpacer: true, VDivider: true, VProgressLinear: true, VEmptyState: true,
   VAlert: { template: '<div role="alert"><slot /></div>' },
   VTooltip: { template: '<div><slot name="activator" :props="{}" /><slot /></div>' },
-  VHotkey: true,
+  VHotkey: hotkeyStub,
 }
 
 describe('CodeViewer controls', () => {

--- a/aas-web-ui/tests/components/Code/QueryLanguageShortcuts.test.ts
+++ b/aas-web-ui/tests/components/Code/QueryLanguageShortcuts.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent, nextTick } from 'vue'
 import QueryLanguageEditor from '@/components/QueryLanguage/QueryLanguageEditor.vue'
 import { shortcuts } from '@/pages/modules/QueryLanguage.vue'
+import { hotkeyStub } from '../../helpers/vuetifyStubs'
 
 vi.mock('@/components/QueryLanguage/monacoQueryLanguage', () => ({ queryLanguageSchemas: [] }))
 vi.mock('@/composables/RequestHandling', () => ({ useRequestHandling: vi.fn() }))
@@ -21,7 +22,7 @@ async function mountEditor () {
     props: { modelValue: '' },
     attrs: { id: 'query-language-editor' },
     attachTo: document.body,
-    global: { stubs: { CodeEditor: editor, VHotkey: true, VProgressLinear: true, VAlert: true } },
+    global: { stubs: { CodeEditor: editor, VHotkey: hotkeyStub, VProgressLinear: true, VAlert: true } },
   })
   await vi.dynamicImportSettled()
   await flushPromises()
@@ -37,7 +38,7 @@ describe('Query Language command palette shortcuts', () => {
     const wrapper = await mountEditor()
     const [command] = shortcuts({ route: { name: 'QueryLanguage' } as RouteLocationNormalizedLoaded })
     expect(command.title).toBe('Show Query Suggestions')
-    expect(wrapper.get('v-hotkey-stub').attributes('keys')).toBe(command.keys)
+    expect(wrapper.getComponent(hotkeyStub).props('keys')).toBe(command.keys)
     command.handler(new KeyboardEvent('keydown'))
     expect(suggest).not.toHaveBeenCalled()
     await nextTick()

--- a/aas-web-ui/tests/components/Plugins/Submodels/ProductionPlan_v1_0.test.ts
+++ b/aas-web-ui/tests/components/Plugins/Submodels/ProductionPlan_v1_0.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/composables/JumpHandling', () => ({
 const MACHINE_AAS_ID = 'https://aas.dev.chesco.de/ids/aas/machine/AN16'
 
 // Stubs that pass through slot content so nested template logic is testable
-const slotStub = { template: '<slot />' }
+const slotStub = { template: '<div><slot /></div>' }
 
 const globalStubs = {
   'v-container': slotStub,
@@ -55,7 +55,7 @@ const globalStubs = {
   'v-list-item-subtitle': slotStub,
   'v-chip': true,
   'v-spacer': true,
-  'v-btn': { template: '<v-btn-stub><slot /></v-btn-stub>' },
+  'v-btn': { template: '<button><slot /></button>' },
   'v-icon': true,
 }
 
@@ -200,7 +200,7 @@ describe('ProductionPlan_v1_0.vue – MachineRef navigation', () => {
       const wrapper = createWrapper(createSubmodelData(false))
       await nextTick()
 
-      expect(wrapper.find('v-btn-stub').exists()).toBe(false)
+      expect(wrapper.find('button').exists()).toBe(false)
       expect(wrapper.text()).toContain('Welding Robot AN16')
     })
 
@@ -208,17 +208,16 @@ describe('ProductionPlan_v1_0.vue – MachineRef navigation', () => {
       const wrapper = createWrapper(createSubmodelData(true))
       await nextTick()
 
-      expect(wrapper.find('v-btn-stub').exists()).toBe(true)
-      expect(wrapper.find('v-btn-stub').text()).toContain('Welding Robot AN16')
+      expect(wrapper.get('button').text()).toContain('Welding Robot AN16')
     })
   })
 
   describe('navigation', () => {
     it('calls jumpToAasById with the machine AAS ID', async () => {
       const wrapper = createWrapper(createSubmodelData(true))
-      const vm = wrapper.vm as any
+      await nextTick()
 
-      await vm.navigateToMachine(MACHINE_AAS_ID)
+      await wrapper.get('button').trigger('click')
 
       expect(jumpToAasByIdMock).toHaveBeenCalledOnce()
       expect(jumpToAasByIdMock).toHaveBeenCalledWith(MACHINE_AAS_ID)

--- a/aas-web-ui/tests/components/SubmodelLoading.test.ts
+++ b/aas-web-ui/tests/components/SubmodelLoading.test.ts
@@ -129,6 +129,29 @@ const slotStub = {
   template: '<div><slot /></div>',
 }
 
+// Consume the component prop without forwarding it to the read-only DOM property.
+const editorFormStub = {
+  props: ['parentElement'],
+  template: '<div />',
+}
+
+const editorFormStubs = {
+  SubmodelElementForm: editorFormStub,
+  PropertyForm: editorFormStub,
+  MLPForm: editorFormStub,
+  RangeForm: editorFormStub,
+  FileForm: editorFormStub,
+  BlobForm: editorFormStub,
+  CollectionForm: editorFormStub,
+  ListForm: editorFormStub,
+  EntityForm: editorFormStub,
+  ReferenceElementForm: editorFormStub,
+  RelationshipElementForm: editorFormStub,
+  AnnotatedRelationshipElementForm: editorFormStub,
+  JsonInsert: editorFormStub,
+  SubmodelElementDraftForm: editorFormStub,
+}
+
 describe('Submodel loading invalidation', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -151,7 +174,7 @@ describe('Submodel loading invalidation', () => {
     mocks.fetchAasSmListById.mockReturnValue(new Promise(resolve => {
       resolveLoad = resolve
     }))
-    const wrapper = mount(component, { shallow: true })
+    const wrapper = mount(component, { shallow: true, global: { stubs: editorFormStubs } })
     await flushPromises()
 
     expect((wrapper.vm as any)[loadingProperty]).toBe(true)
@@ -181,6 +204,7 @@ describe('Submodel loading invalidation', () => {
       shallow: true,
       global: {
         stubs: {
+          ...editorFormStubs,
           'Treeview': treeviewStub,
           'ConvertSubmodelToInstanceDialog': conversionDialogStub,
           'v-container': slotStub,

--- a/aas-web-ui/tests/components/UIComponents/GlobalAssetQrCode.test.ts
+++ b/aas-web-ui/tests/components/UIComponents/GlobalAssetQrCode.test.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import GlobalAssetQrCode from '@/components/UIComponents/GlobalAssetQrCode.vue'
 
 const { toDataURLMock } = vi.hoisted(() => ({
@@ -18,6 +18,10 @@ async function flushAsync (): Promise<void> {
 }
 
 describe('GlobalAssetQrCode.vue', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   beforeEach(() => {
     toDataURLMock.mockReset()
     toDataURLMock.mockResolvedValue('data:image/png;base64,qr')
@@ -60,7 +64,9 @@ describe('GlobalAssetQrCode.vue', () => {
   })
 
   it('falls back to empty output when QR generation fails', async () => {
-    toDataURLMock.mockRejectedValueOnce(new Error('QR generation error'))
+    const error = new Error('QR generation error')
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    toDataURLMock.mockRejectedValueOnce(error)
 
     const wrapper = mount(GlobalAssetQrCode, {
       props: {
@@ -71,6 +77,7 @@ describe('GlobalAssetQrCode.vue', () => {
     await flushAsync()
 
     expect(toDataURLMock).toHaveBeenCalledTimes(1)
+    expect(errorSpy).toHaveBeenCalledExactlyOnceWith(error)
     expect(wrapper.find('[data-testid="global-asset-qr-code"]').exists()).toBe(false)
   })
 

--- a/aas-web-ui/tests/composables/AAS/SMEHandlingOperationFragment.test.ts
+++ b/aas-web-ui/tests/composables/AAS/SMEHandlingOperationFragment.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   fetchSme: vi.fn(),
@@ -19,6 +19,10 @@ vi.mock('@/store/AASDataStore', () => ({
 }))
 
 describe('SMEHandling Operation fragments', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('fetches the owning Operation endpoint and resolves the fragment locally', async () => {
     mocks.fetchSme.mockResolvedValue({
       modelType: 'Operation',
@@ -43,6 +47,7 @@ describe('SMEHandling Operation fragments', () => {
   })
 
   it('never submits a malformed fragment as a repository endpoint', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     mocks.fetchSme.mockResolvedValue({ modelType: 'Operation', inputVariables: [] })
     const endpoint = '/submodels/c20/submodel-elements/operation'
     const { useSMEHandling } = await import('@/composables/AAS/SMEHandling')
@@ -50,6 +55,7 @@ describe('SMEHandling Operation fragments', () => {
     const result = await useSMEHandling().fetchSme(endpoint, false, '/inputVariables/0/constructor')
 
     expect(result).toEqual({})
+    expect(warnSpy).toHaveBeenCalledExactlyOnceWith('Resolving Operation fragment \'/inputVariables/0/constructor\' failed!')
     expect(mocks.fetchSme).toHaveBeenCalledWith(endpoint)
     expect(mocks.fetchSme).not.toHaveBeenCalledWith(expect.stringContaining('constructor'))
   })

--- a/aas-web-ui/tests/helpers/vuetifyStubs.ts
+++ b/aas-web-ui/tests/helpers/vuetifyStubs.ts
@@ -1,0 +1,7 @@
+import { defineComponent } from 'vue'
+
+// Consume prefix rather than forwarding it to the read-only DOM property.
+export const hotkeyStub = defineComponent({
+  props: ['keys', 'prefix'],
+  template: '<span>{{ keys }}</span>',
+})

--- a/aas-web-ui/tests/router/OAuth2CallbackRouting.test.ts
+++ b/aas-web-ui/tests/router/OAuth2CallbackRouting.test.ts
@@ -136,6 +136,7 @@ describe('OAuth2 callback routing', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
     sessionStorage.clear()
   })
@@ -279,12 +280,18 @@ describe('OAuth2 callback routing', () => {
   })
 
   it('rejects an issuer injected into the authorization response', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     const { state } = startAuthorizationTransaction('infrastructure-1')
     const router = await createAppRouter()
 
     await router.push(`/?code=authorization-code&state=${state}&iss=${encodeURIComponent('https://attacker.example')}`)
 
     expect(mockDeps.exchangeOAuth2AuthorizationCode).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledExactlyOnceWith(
+      '[OAuth2 Callback] Failed:',
+      'OAuth2 response issuer does not match the configured identity provider',
+      expect.objectContaining({ message: 'OAuth2 response issuer does not match the configured identity provider' }),
+    )
     expect(mockDeps.clearOAuth2AuthorizationCodeState).toHaveBeenCalledWith(state)
     expect(mockDeps.navigationStore.dispatchSnackbar).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/aas-web-ui/tests/router/moduleRouteManifest.test.ts
+++ b/aas-web-ui/tests/router/moduleRouteManifest.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { createMemoryHistory, createRouter, type RouteRecordRaw } from 'vue-router'
 import CompanyDescriptorViewer from '@/pages/modules/CompanyDescriptorViewer/index.vue'
@@ -14,6 +14,10 @@ const DummyView = defineComponent({
 })
 
 describe('module manifest child routes', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it('creates prefixed child route names and inherits module meta defaults', () => {
     const children = buildValidatedModuleChildRoutes(
       'Dpp',
@@ -88,6 +92,7 @@ describe('module manifest child routes', () => {
   })
 
   it('rejects child routes that escape module namespace', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
     const children = buildValidatedModuleChildRoutes(
       'Dpp',
       '/modules/dpp',
@@ -114,6 +119,10 @@ describe('module manifest child routes', () => {
 
     expect(children).toHaveLength(1)
     expect(children[0].path).toBe('allowed')
+    expect(warnSpy.mock.calls).toEqual([
+      ['[Module Router] Ignored invalid child route "/outside" in module "Dpp". Child routes must be relative and stay below /modules/dpp/**.'],
+      ['[Module Router] Ignored invalid child route "../outside" in module "Dpp". Child routes must be relative and stay below /modules/dpp/**.'],
+    ])
   })
 
   it('supports deep-link matching for module child routes', async () => {


### PR DESCRIPTION
## Description of Changes

Fix the Vue warnings reported when running the unit tests. The tests were passing, but the warnings made it harder to spot actual problems.

- Fix the slot and button stubs in the ProductionPlan tests and test navigation through a button click.
- Use explicit form and hotkey stubs so read-only DOM properties are not overwritten.
- Capture and assert expected error and warning logs in the failure tests.
- Replace the deprecated `dense` prop with `density="compact"` in the Time Series controls.

## Related Issue

Fixes #1428

## BaSyx Configuration for Testing

No running BaSyx infrastructure is needed. Run from `aas-web-ui`:

```sh
pnpm exec vitest run --silent=false --reporter=verbose
pnpm lint:check
pnpm type-check
```

All 1,336 tests pass with no Vue warnings or stderr output. Lint and type checks also pass.

## AAS Files Used for Testing

The existing test fixtures are sufficient; no external AAS files are needed.

## Additional Information

Warnings remain enabled globally. Expected logs are only captured in the tests that trigger them.
