### PR TITLE
fix: accept AAS and Submodel 3.x descriptor interfaces

### DIFF
--- a/aas-web-ui/src/utils/AAS/DescriptorUtils.ts
+++ b/aas-web-ui/src/utils/AAS/DescriptorUtils.ts
@@ -1,5 +1,7 @@
 /**
  * Extracts the endpoint from a descriptor based on the given interface short name.
+ * AAS and Submodel 3.x requests also accept other numeric 3.x versions,
+ * preferring exact matches and direct interfaces over repository fallbacks.
  *
  * @param {Object} descriptor_or_model - The descriptor or model (AAS / Submodel) containing endpoint information.
  * @param {string} interfaceShortName - The short name of the interface to match against endpoint interfaces.
@@ -52,22 +54,15 @@ export function extractEndpointHref (descriptor_or_model: any, interfaceShortNam
     return endpoint?.interface === interfaceShortName
   })
 
-  // If not found and it's AAS-3.X, try AAS-REPOSITORY-3.X as fallback
-  if (!endpoint && /^AAS-3\.[^-]+$/.test(interfaceShortName)) {
-    const versionPart = interfaceShortName.slice('AAS-'.length) // e.g., "3.0"
-    const fallbackInterface = 'AAS-REPOSITORY-' + versionPart
-    endpoint = endpoints.find((endpoint: any) => {
-      return endpoint?.interface === fallbackInterface
-    })
-  }
+  const versionedInterface = /^(AAS|SUBMODEL)-(3\.\d+(?:\.\d+)*)$/.exec(interfaceShortName)
+  if (!endpoint && versionedInterface) {
+    const [, interfaceName, version] = versionedInterface
+    const directInterfacePattern = new RegExp(String.raw`^${interfaceName}-3\.\d+(?:\.\d+)*$`)
+    const repositoryInterfacePattern = new RegExp(String.raw`^${interfaceName}-REPOSITORY-3\.\d+(?:\.\d+)*$`)
 
-  // If not found and it's SUBMODEL-3.X, try SUBMODEL-REPOSITORY-3.X as fallback
-  if (!endpoint && /^SUBMODEL-3\.[^-]+$/.test(interfaceShortName)) {
-    const versionPart = interfaceShortName.slice('SUBMODEL-'.length) // e.g., "3.0"
-    const fallbackInterface = 'SUBMODEL-REPOSITORY-' + versionPart
-    endpoint = endpoints.find((endpoint: any) => {
-      return endpoint?.interface === fallbackInterface
-    })
+    endpoint = endpoints.find((endpoint: any) => directInterfacePattern.test(endpoint?.interface))
+      ?? endpoints.find((endpoint: any) => endpoint?.interface === `${interfaceName}-REPOSITORY-${version}`)
+      ?? endpoints.find((endpoint: any) => repositoryInterfacePattern.test(endpoint?.interface))
   }
 
   return endpoint?.protocolInformation?.href || ''

--- a/aas-web-ui/tests/utils/AAS/DescriptorUtils.test.ts
+++ b/aas-web-ui/tests/utils/AAS/DescriptorUtils.test.ts
@@ -210,3 +210,61 @@ describe('DescriptorUtils.ts; Tests for \'extractEndpointHref()\'', () => {
     })
   }
 })
+
+describe.each(['AAS', 'SUBMODEL'])('%s 3.x endpoint resolution', interfaceName => {
+  function descriptor (...interfaces: string[]) {
+    return {
+      endpoints: interfaces.map(name => ({
+        interface: name,
+        protocolInformation: { href: `https://example.com/${name}` },
+      })),
+    }
+  }
+
+  it.each(['3.0', '3.1', '3.2', '3.10', '3.123', '3.2.1'])('accepts version %s', version => {
+    const advertisedInterface = `${interfaceName}-${version}`
+    expect(extractEndpointHref(descriptor(advertisedInterface), `${interfaceName}-3.0`))
+      .toBe(`https://example.com/${advertisedInterface}`)
+  })
+
+  it('matches other 3.x versions when the requested minor version is newer', () => {
+    expect(extractEndpointHref(descriptor(`${interfaceName}-3.0`), `${interfaceName}-3.2`))
+      .toBe(`https://example.com/${interfaceName}-3.0`)
+  })
+
+  it('prefers an exact match regardless of endpoint order', () => {
+    expect(extractEndpointHref(descriptor(`${interfaceName}-3.2`, `${interfaceName}-3.0`), `${interfaceName}-3.0`))
+      .toBe(`https://example.com/${interfaceName}-3.0`)
+  })
+
+  it.each(['3.0', '3.2', '3.10', '3.2.1'])('falls back to a repository endpoint with version %s', version => {
+    const advertisedInterface = `${interfaceName}-REPOSITORY-${version}`
+    expect(extractEndpointHref(descriptor(advertisedInterface), `${interfaceName}-3.0`))
+      .toBe(`https://example.com/${advertisedInterface}`)
+  })
+
+  it('prefers a direct 3.x endpoint over a repository fallback', () => {
+    expect(extractEndpointHref(descriptor(`${interfaceName}-REPOSITORY-3.0`, `${interfaceName}-3.2`), `${interfaceName}-3.0`))
+      .toBe(`https://example.com/${interfaceName}-3.2`)
+  })
+
+  it('prefers the requested repository version over other repository versions', () => {
+    expect(extractEndpointHref(descriptor(`${interfaceName}-REPOSITORY-3.2`, `${interfaceName}-REPOSITORY-3.0`), `${interfaceName}-3.0`))
+      .toBe(`https://example.com/${interfaceName}-REPOSITORY-3.0`)
+  })
+
+  it.each(['2.0', '4.0', '30.0', '3', '3.', '3.x', '3.2-preview', '3.2junk'])('rejects incompatible or malformed version %s', version => {
+    expect(extractEndpointHref(descriptor(`${interfaceName}-${version}`, `${interfaceName}-REPOSITORY-${version}`), `${interfaceName}-3.0`))
+      .toBe('')
+  })
+
+  it('does not match other interface families', () => {
+    const otherInterface = interfaceName === 'AAS' ? 'SUBMODEL' : 'AAS'
+    expect(extractEndpointHref(descriptor(`${otherInterface}-3.2`, `${interfaceName}-REGISTRY-3.2`), `${interfaceName}-3.0`))
+      .toBe('')
+  })
+
+  it('does not extend matching to other requested major versions', () => {
+    expect(extractEndpointHref(descriptor(`${interfaceName}-3.2`), `${interfaceName}-4.0`)).toBe('')
+  })
+})


### PR DESCRIPTION
## Description of Changes

Selecting an AAS advertised as `AAS-3.2` currently resolves to an empty endpoint and navigates to `?aas=`, leaving the viewer without a selected shell. This occurs with the BaSyx Go Event Feed example because the UI requests `AAS-3.0` and only accepts an exact interface version. Submodel descriptor resolution has the same limitation.

Update the shared endpoint resolver to accept `AAS-3.X` and `SUBMODEL-3.X` for any numeric minor version, including multi-digit versions. Preserve numeric patch-version support and apply the same matching to repository fallbacks. Prefer the exact requested interface, then another direct 3.x interface, then the exact repository version, then another repository 3.x version. Matching stays within the requested interface family and major version.

Add 48 regression cases covering both interface families, minor and patch versions, endpoint priority, repository fallbacks, and rejection of unrelated interfaces or incompatible/malformed fallback versions.

## Related Issue

No linked issue.

## BaSyx Configuration for Testing

Run the BaSyx Go `examples/BaSyxEventFeedExample` stack with its `mono-all` infrastructure configuration pointing to the environment at `http://localhost:8082`. Serve this branch's UI using that infrastructure configuration.

Verified normal list selection of `EventFeedPlayground` and opening `NoSemanticId` submodel details against the running example, whose descriptors advertise `AAS-3.2` and `SUBMODEL-3.2`.

## AAS Files Used for Testing

The Event Feed example's bundled `EventFeedPlayground` shell (`urn:example:eventing:aas:playground`), with its `NoSemanticId` and `ProductChangeNotifications` submodels. Unit tests use inline descriptor fixtures.

## Additional Information

Validation:

- New regression suite before the fix: 20 failures reproducing the matching problem.
- `pnpm lint:check` passed.
- `pnpm test:run` passed: 135 files, 1,494 tests.
- `pnpm type-check` passed.
- `BASE=/ pnpm build-only` passed, with chunk-size and dynamic-import warnings.
- Final endpoint resolver suite passed: 62 tests.
- Browser verification used the current branch's Vite UI against the live Go backend.
